### PR TITLE
feat(v0.5.3): antigravity MCP config 표준화 + cross-language stack 표시

### DIFF
--- a/ai-workflow/memory/release/v0.5.3/PROJECT_PROFILE.md
+++ b/ai-workflow/memory/release/v0.5.3/PROJECT_PROFILE.md
@@ -1,0 +1,47 @@
+# Project Workflow Profile
+
+- 문서 목적: Standard AI Workflow 저장소 자체의 운영 규칙과 검증 기준을 정의한다.
+- 범위: 저장소 개요, 문서 구조, 기본 명령, 검증 포인트, 예외 규칙
+- 대상 독자: 저장소 maintainer, 멀티 에이전트 운영자, AI agent
+- 상태: stable
+- 최종 수정일: 2026-06-07
+- 관련 문서: [공통 표준](../../../../workflow-source/core/global_workflow_standard.md), [Maturity Matrix](../../../../workflow-source/core/maturity_matrix.json), [Bootstrap Script](../../../../workflow-source/scripts/bootstrap_workflow_kit.py)
+
+## 1. 프로젝트 개요
+
+- 프로젝트명: **Standard AI Workflow**
+- 프로젝트 슬러그: `standard-ai-workflow`
+- 프로젝트 목적: 여러 프로젝트에서 공통으로 사용할 수 있는 표준 AI 협업 워크플로우 문서와 템플릿, skill/MCP/agent 구현 기준을 독립 프로젝트 형태로 제공한다.
+- 주요 이해관계자: 저장소 maintainer (`ykylee`), 워크플로우 도입 검토자, 멀티 에이전트 운영자
+
+## 2. 문서 구조 (Path)
+
+- 문서 위키 홈: [`docs/README.md`](../../../../docs/README.md)
+- 운영 문서 홈: `ai-workflow/memory/`
+- 백로그 위치: `ai-workflow/memory/backlog/`
+- 세션 인계 문서: `ai-workflow/memory/session_handoff.md`
+- 환경 기록 위치: `ai-workflow/memory/environments/`
+
+## 3. 운영 / 검증 명령
+
+- bootstrap dry-run: `python3 workflow-source/scripts/bootstrap_workflow_kit.py --target-root . --project-slug demo --project-name "Demo" --harness codex --dry-run`
+- bootstrap 실제 실행: `python3 workflow-source/scripts/bootstrap_workflow_kit.py --target-root . --project-slug demo --project-name "Demo" --harness codex --copy-core-docs`
+- 회귀: `python3 workflow-source/tests/check_bootstrap.py`
+- 회귀 (MCP): `python3 workflow-source/tests/check_bootstrap_mcp_roundtrip.py`
+- 문서 링크 검증: `python3 workflow-source/tests/check_docs.py`
+- 워크플로우 linter: `PYTHONPATH=workflow-source python3 workflow-source/skills/workflow-linter/scripts/run_workflow_linter.py --project-profile-path docs/PROJECT_PROFILE.md --state-json-path ai-workflow/memory/release/v0.5.3/state.json --session-handoff-path ai-workflow/memory/release/v0.5.3/session_handoff.md --latest-backlog-path ai-workflow/memory/release/v0.5.3/backlog/2026-06-07.md`
+
+## 4. 예외 규칙
+
+- 새 하네스 overlay 추가 시 `bootstrap_lib/harnesses/` 아래에 renderer + `HARNESS_SPECS` 등록 + `__main__.py` 의 `register_harness_builder` 호출이 모두 세트로 들어가야 한다.
+- `bootstrap_workflow_kit.py` 는 thin re-export entry. 직접 import 하지 말고 `bootstrap_lib.*` 사용.
+- `--enable-mcp` 의 MCP config 출력 경로는 하네스별 dot-dir 컨벤션(`.codex/`, `.gemini/`, `.MiniMax/`, `.antigravity/`)을 따른다.
+- `requirements.txt` / `package.json` 자동 갱신은 `--update-deps` 옵션일 때만.
+- 승인: `core/` 문서 (특히 `global_workflow_standard.md`, `maturity_matrix.json`) 변경 시 자체 self-review 필수
+
+## 5. 다음에 읽을 문서
+
+- [Maturity Matrix](../../../../workflow-source/core/maturity_matrix.json)
+- [세션 인계 문서](./session_handoff.md)
+- [작업 백로그 인덱스](../../work_backlog.md)
+- [릴리스 노트](../../../../workflow-source/releases/Beta-v0.5.2.md)

--- a/ai-workflow/memory/release/v0.5.3/backlog/2026-06-07.md
+++ b/ai-workflow/memory/release/v0.5.3/backlog/2026-06-07.md
@@ -1,0 +1,83 @@
+# 2026-06-07 작업 백로그 (release/v0.5.3)
+
+- 문서 목적: 2026-06-07 세션에서 release/v0.5.3 브랜치에서 처리한 작업을 기록한다.
+- 범위: TASK-V053-001 (antigravity MCP config 표준화), TASK-V053-002 (cross-language stack 표시)
+- 대상 독자: AI 에이전트, 저장소 maintainer
+- 상태: in_progress
+- 최종 수정일: 2026-06-07
+- 관련 문서: [`../session_handoff.md`](../session_handoff.md), [`../../../work_backlog.md`](../../../work_backlog.md), [`../PROJECT_PROFILE.md`](../PROJECT_PROFILE.md)
+
+## TASK-V053-001 antigravity MCP config 경로 표준화
+
+- 상태: in_progress
+- 우선순위: medium
+- 요청일: 2026-06-07
+- 완료일:
+- 담당: yklee (Mavis / MiniMax Code orchestrator)
+- 호스트명: yklee-ui-MacBookAir.local
+- 호스트 IP: 192.168.0.139
+- 영향 문서: `bootstrap_lib/mcp.py`, `harnesses/antigravity/apply_guide.md`, `core/mcp_installation_by_harness.md`, `tests/check_bootstrap.py`, `examples/pilot_validation_devhub_example.md`
+
+### 작업 내용
+
+- `antigravity.mcp.json` (project root, suffixed) → `.antigravity/mcp.json` (dot-dir, 다른 3개 하네스 컨벤션과 일치)
+- `.codex/mcp.toml`, `.gemini/mcp.json`, `.MiniMax/mcp.json` 와 같은 dot-dir 패턴
+- antigravity 글로벌 `~/.antigravity/mcp.json` 으로 copy 패턴은 유지
+
+### 진행 현황
+
+- 2026-06-07 10:38 시작
+- 2026-06-07 10:40 `bootstrap_lib/mcp.py` path + docstring 갱신
+- 2026-06-07 10:42 `apply_guide.md` 4개 참조 갱신
+- 2026-06-07 10:43 `mcp_installation_by_harness.md` 2개 참조 갱신
+- 2026-06-07 10:44 `check_bootstrap.py` expected key 갱신
+
+### 완료 기준
+
+- [x] `bootstrap_lib/mcp.py` 경로 변경
+- [x] `apply_guide.md` 4개 참조 갱신
+- [x] `mcp_installation_by_harness.md` 2개 참조 갱신
+- [x] `check_bootstrap.py` 단언문 갱신
+- [x] `check_bootstrap.py` 8/8 PASS
+- [x] `check_bootstrap_mcp_roundtrip.py` 5/5 PASS
+- [x] `check_docs.py` 99/99 PASS
+
+## TASK-V053-002 cross-language stack 표시
+
+- 상태: in_progress
+- 우선순위: medium
+- 요청일: 2026-06-07
+- 완료일:
+- 담당: yklee (Mavis / MiniMax Code orchestrator)
+- 호스트명: yklee-ui-MacBookAir.local
+- 호스트 IP: 192.168.0.139
+- 영향 문서: `bootstrap_lib/writes.py`, `bootstrap_lib/renderers.py`, `tests/check_bootstrap.py`
+
+### 작업 내용
+
+- `build_manifest` 에 `stack_labels: list[str]` + `multi_stack: bool` 필드 추가
+- `render_session_handoff` existing 모드: 다중 스택이면 "all detected stacks: X, Y, Z" 추가 표시
+- `check_bootstrap.py` 에 `check_multi_stack_detection` 신규 테스트 추가
+  - 3개 언어 fixture (package.json + pyproject.toml + go.mod) 로 multi_stack=True 검증
+  - manifest 의 stack_labels 에 3개 모두 포함되는지 검증
+  - assessment 에 stack 라벨들이 표시되는지 검증
+
+### 진행 현황
+
+- 2026-06-07 10:45 시작
+- 2026-06-07 10:47 `writes.py` 의 `build_manifest` 에 stack_labels + multi_stack 추가
+- 2026-06-07 10:48 `renderers.py` 의 `render_session_handoff` existing 모드 multi-stack 표시
+- 2026-06-07 10:50 `check_bootstrap.py` 에 `check_multi_stack_detection` 추가
+- 2026-06-07 10:52 check_bootstrap.py 8/8 PASS (multi_stack 테스트 포함)
+- 2026-06-07 10:55 실제 multi-stack fixture (Go+Node+Python) 으로 manifest 출력 확인
+  - primary_stack=go, stack_labels=['go','node','python'], multi_stack=True ✓
+  - handoff: "inferred primary stack: go; all detected stacks: go, node, python" ✓
+  - assessment: "추정 기본 스택: `go`" / "감지된 스택 라벨: `go, node, python`" ✓
+
+### 완료 기준
+
+- [x] `build_manifest` 에 stack_labels + multi_stack 노출
+- [x] `render_session_handoff` existing 모드 multi-stack 표시
+- [x] `check_multi_stack_detection` 신규 테스트 추가
+- [x] 8/8 회귀 PASS
+- [x] 실제 multi-stack fixture 출력 확인

--- a/ai-workflow/memory/release/v0.5.3/session_handoff.md
+++ b/ai-workflow/memory/release/v0.5.3/session_handoff.md
@@ -1,0 +1,47 @@
+# Session Handoff
+
+- 문서 목적: 현재 세션의 작업 상태와 다음 세션을 위한 인계 사항을 정리한다.
+- 범위: 현재 focus, 진행 중/차단/완료 작업, 핵심 변경, 다음 액션, 리스크
+- 대상 독자: AI 에이전트, 저장소 maintainer
+- 상태: in_progress
+- 최종 수정일: 2026-06-07
+- 관련 문서: [./state.json](./state.json), [../../work_backlog.md](../../work_backlog.md), [./PROJECT_PROFILE.md](./PROJECT_PROFILE.md)
+
+## Current Focus
+
+- **현재 브랜치**: `release/v0.5.3` (main #9497a35 에서 분기, 2026-06-07)
+- **현재 주 작업 축**: v0.5.3 = v0.5.2 의 deferred 2개 항목 + 신규 통합
+  - TASK-V053-001: antigravity MCP config 경로 표준화 (`antigravity.mcp.json` → `.antigravity/mcp.json`)
+  - TASK-V053-002: cross-language stack 표시 (manifest 에 `stack_labels` + `multi_stack` 필드, README/assessment 가 모든 감지 스택 표시)
+- **현재 기준선**: main 은 v0.5.2 까지 stable. v0.5.3 는 main 에서 분기, 0 commit. `ai-workflow/memory/release/v0.5.3/` 디렉터리 부트스트랩 진행 중
+- **메모리 layer 연속성**: v0.5.2 의 memory layer 가 같은 패턴으로 v0.5.3 에도 이식됨
+
+## Work Status
+
+- TASK-V053-001 antigravity MCP config 경로 표준화: in_progress
+- TASK-V053-002 cross-language stack 표시: in_progress
+- (v0.5.2 의 TASK-V052-001/002/003 done — history 보존)
+- (v0.5.1 의 TASK-V051-001..006 done — history 보존)
+
+## Key Changes
+
+(세션 진행하면서 누적 기록 예정)
+
+## Next Actions
+
+- TASK-V053-001 + TASK-V053-002 회귀 (check_bootstrap.py 8/8 + roundtrip 5/5 + docs 99/99)
+- 단일 PR (v0.5.3-alpha) 로 머지
+- v0.5.3-beta 태그 + release 노트 (Beta-v0.5.3.md)
+- 다음: TASK-V053-003 mini-coder-max / general agent 통합 검증 (외부 contract 명시 후)
+
+## Risks & Blockers
+
+- **리스크 #1 (LOW)**: antigravity 경로 변경은 apply_guide.md / mcp_installation_by_harness.md / examples 까지 4개 문서 갱신. 사용자 환경에서 이미 `antigravity.mcp.json` 을 사용 중이면 수동 마이그레이션 필요 (CHANGELOG 에 명시)
+- **리스크 #2 (LOW)**: cross-language stack 표시가 render_session_handoff 의 "Existing codebase onboarding completed" 라인 1줄만 추가 — 기존 단언문 회귀 가능성 낮음
+- **제약**: Python 3.10+, smoke test 회귀 0, linter status ok
+
+## 다음에 읽을 문서
+
+- [TASK-V053-001](./backlog/2026-06-07.md#task-v053-001)
+- [TASK-V053-002](./backlog/2026-06-07.md#task-v053-002)
+- [Maturity Matrix](../../../../workflow-source/core/maturity_matrix.json)

--- a/ai-workflow/memory/release/v0.5.3/state.json
+++ b/ai-workflow/memory/release/v0.5.3/state.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "1",
+  "generated_at": "2026-06-07",
+  "source_of_truth": {
+    "project_profile_path": "docs/PROJECT_PROFILE.md",
+    "session_handoff_path": "ai-workflow/memory/release/v0.5.3/session_handoff.md",
+    "work_backlog_index_path": "ai-workflow/memory/work_backlog.md",
+    "latest_backlog_path": "ai-workflow/memory/release/v0.5.3/backlog/2026-06-07.md",
+    "repository_assessment_path": null
+  },
+  "project": {
+    "project_name": "Standard AI Workflow",
+    "document_home": "docs/README.md",
+    "operations_path": null,
+    "backlog_path": "ai-workflow/memory/backlog/",
+    "handoff_path": null,
+    "environment_path": "ai-workflow/memory/environments/"
+  },
+  "commands": {
+    "quick_tests": null,
+    "isolated_tests": null,
+    "runtime_checks": null
+  },
+  "session": {
+    "current_baseline": "**현재 브랜치**: `release/v0.5.3` (main #9497a35 에서 분기, 2026-06-07)",
+    "current_axis": "**현재 브랜치**: `release/v0.5.3` (main #9497a35 에서 분기, 2026-06-07)",
+    "current_focus": "TASK-V053-001 antigravity MCP config 경로 표준화",
+    "in_progress_items": [
+      "TASK-V053-001 antigravity MCP config 경로 표준화",
+      "TASK-V053-002 cross-language stack 표시"
+    ],
+    "blocked_items": [],
+    "recent_done_items": [],
+    "environment_constraints": []
+  },
+  "backlog": {
+    "latest_backlog_path": "ai-workflow/memory/release/v0.5.3/backlog/2026-06-07.md",
+    "task_count": 2,
+    "in_progress_items": [
+      "TASK-V053-001 antigravity MCP config 경로 표준화",
+      "TASK-V053-002 cross-language stack 표시"
+    ],
+    "blocked_items": [],
+    "done_items": []
+  },
+  "next_documents": [
+    "docs/PROJECT_PROFILE.md",
+    "ai-workflow/memory/release/v0.5.3/session_handoff.md",
+    "ai-workflow/memory/work_backlog.md",
+    "ai-workflow/memory/release/v0.5.3/backlog/2026-06-07.md",
+    "ai-workflow/memory/release/v0.5.3/PROJECT_PROFILE.md",
+    "workflow-source/core/maturity_matrix.json"
+  ],
+  "repository_assessment": {
+    "path": null,
+    "present": false
+  }
+}

--- a/ai-workflow/memory/work_backlog.md
+++ b/ai-workflow/memory/work_backlog.md
@@ -15,6 +15,9 @@
 
 ## 최근 작업 백로그
 
+### release/v0.5.3 (2026-06-07)
+- [2026-06-07 작업 백로그](./release/v0.5.3/backlog/2026-06-07.md) — v0.5.3 2개 TASK (antigravity MCP config 표준화 / cross-language stack 표시)
+
 ### release/v0.5.2 (2026-06-06)
 - [2026-06-06 작업 백로그](./release/v0.5.2/backlog/2026-06-06.md) — v0.5.2 3개 TASK (bootstrap 풀 리팩터 / workflow_kit 패키지화 / 외부 pilot validation)
 
@@ -27,6 +30,8 @@
 
 ## 다음에 읽을 문서
 
+- [release/v0.5.3/session_handoff.md](./release/v0.5.3/session_handoff.md)
+- [release/v0.5.3/backlog/2026-06-07.md](./release/v0.5.3/backlog/2026-06-07.md)
 - [release/v0.5.2/session_handoff.md](./release/v0.5.2/session_handoff.md)
 - [release/v0.5.2/backlog/2026-06-06.md](./release/v0.5.2/backlog/2026-06-06.md)
 - [Maturity Matrix](../../workflow-source/core/maturity_matrix.json)

--- a/workflow-source/core/mcp_installation_by_harness.md
+++ b/workflow-source/core/mcp_installation_by_harness.md
@@ -32,7 +32,7 @@
 | **Codex** | `~/.codex/config.toml` (`[mcp_servers.<alias>]` 섹션) | `<root>/.codex/mcp.toml` | TOML |
 | **OpenCode** | `opencode.json` 의 `"mcp": { ... }` 키 | `<root>/mcp.opencode.json` | JSON (top-level `mcp` 키) |
 | **Gemini CLI** | `~/.gemini/settings.json` 의 `"mcpServers": { ... }` | `<root>/.gemini/mcp.json` | JSON (`mcpServers` 키) |
-| **Antigravity** | `~/.MiniMax/antigravity.json` (가정, 하네스별 확인 필요) | `<root>/antigravity.mcp.json` | JSON (`mcpServers` 키) |
+| **Antigravity** | `~/.MiniMax/antigravity.json` (가정, 하네스별 확인 필요) | `<root>/.antigravity/mcp.json` | JSON (`mcpServers` 키) |
 | **MiniMax Code** | `~/.MiniMax/mcp.json` 또는 `~/.MiniMax/config.json` 의 `mcp_servers` | `<root>/.MiniMax/mcp.json` | JSON (`mcp_servers` 키) |
 
 ## 4. 자동 심기 (`bootstrap --enable-mcp`)
@@ -119,7 +119,7 @@ workflow_kit.read_only = "Read-only MCP tools (latest_backlog, check_doc_metadat
 
 ### 5.4 Antigravity
 
-Antigravity 의 정확한 글로벌 설정 경로는 하네스 문서를 참조. 일반적으로 `~/.antigravity/config.json` 에 `mcpServers` 키로 등록 (Gemini CLI 와 동일 스키마). bootstrap 이 emit 한 `antigravity.mcp.json` 의 `mcpServers` 블록을 그대로 복사.
+Antigravity 의 정확한 글로벌 설정 경로는 하네스 문서를 참조. 일반적으로 `~/.antigravity/config.json` 에 `mcpServers` 키로 등록 (Gemini CLI 와 동일 스키마). bootstrap 이 emit 한 `.antigravity/mcp.json` 의 `mcpServers` 블록을 그대로 복사.
 
 ### 5.5 MiniMax Code (`~/.MiniMax/mcp.json` 또는 `~/.MiniMax/config.json`)
 

--- a/workflow-source/harnesses/antigravity/apply_guide.md
+++ b/workflow-source/harnesses/antigravity/apply_guide.md
@@ -20,7 +20,8 @@
 ```
 <project_root>/
 ├── ANTIGRAVITY.md
-└── antigravity.mcp.json   # --enable-mcp 사용 시
+└── .antigravity/
+    └── mcp.json   # --enable-mcp 사용 시
 ```
 
 ## 3. 설정 적용
@@ -39,14 +40,14 @@ python3 workflow-source/scripts/bootstrap_workflow_kit.py \
   --enable-mcp
 ```
 
-`<root>/antigravity.mcp.json` 생성. 글로벌에 등록:
+`<root>/.antigravity/mcp.json` 생성. 글로벌에 등록:
 
 ```bash
 mkdir -p ~/.antigravity
-cp <project_root>/antigravity.mcp.json ~/.antigravity/mcp.json
+cp <project_root>/.antigravity/mcp.json ~/.antigravity/mcp.json
 # 또는
 jq -s '.[0].mcpServers * .[1].mcpServers' \
-   ~/.antigravity/mcp.json <project_root>/antigravity.mcp.json \
+   ~/.antigravity/mcp.json <project_root>/.antigravity/mcp.json \
    > ~/.antigravity/mcp.json.new && mv ~/.antigravity/mcp.json.new ~/.antigravity/mcp.json
 ```
 

--- a/workflow-source/scripts/bootstrap_lib/mcp.py
+++ b/workflow-source/scripts/bootstrap_lib/mcp.py
@@ -137,8 +137,9 @@ def render_antigravity_mcp_config(args: argparse.Namespace, paths: Paths) -> str
     """Return an Antigravity MCP snippet.
 
     Antigravity shares the JSON ``mcpServers`` shape with Gemini CLI. The
-    bootstrap writes the file as ``antigravity.mcp.json`` next to the
-    ``ANTIGRAVITY.md`` overlay.
+    bootstrap writes the file as ``.antigravity/mcp.json`` (project-local),
+    following the same dot-dir convention as ``.codex/``, ``.gemini/``,
+    and ``.MiniMax/``.
     """
     bridge = getattr(args, "mcp_bridge", "jsonrpc-bridge")
     return json.dumps(
@@ -218,7 +219,7 @@ def write_mcp_config_files(
         generated["gemini_cli_mcp_config"] = str(gemini_path)
 
     if "antigravity" in harnesses:
-        antigravity_path = paths.target_root / "antigravity.mcp.json"
+        antigravity_path = paths.target_root / ".antigravity" / "mcp.json"
         write_text(antigravity_path, render_antigravity_mcp_config(args, paths), force=args.force)
         generated["antigravity_mcp_config"] = str(antigravity_path)
 

--- a/workflow-source/scripts/bootstrap_lib/renderers.py
+++ b/workflow-source/scripts/bootstrap_lib/renderers.py
@@ -183,10 +183,15 @@ def render_session_handoff(args: argparse.Namespace, context: dict[str, object])
     risk_or_blocker = "N/A"
 
     if args.adoption_mode == "existing":
-        current_focus = (
-            f"Existing codebase onboarding completed; "
-            f"inferred primary stack: {context['primary_stack']}."
-        )
+        stack_labels = context.get("stack_labels") or []
+        if len(stack_labels) > 1:
+            stack_summary = (
+                f"inferred primary stack: {context['primary_stack']}; "
+                f"all detected stacks: {', '.join(stack_labels)}"
+            )
+        else:
+            stack_summary = f"inferred primary stack: {context['primary_stack']}"
+        current_focus = f"Existing codebase onboarding completed; {stack_summary}."
         completed = "Repository scan completed"
         key_change = "Generated initial workflow docs from the existing repository scan."
         next_action = "Validate generated profile, handoff, and backlog against the repository."

--- a/workflow-source/scripts/bootstrap_lib/writes.py
+++ b/workflow-source/scripts/bootstrap_lib/writes.py
@@ -129,6 +129,13 @@ def build_manifest(
         next_steps.append(
             "Review the recommended global snippet before merging it into your harness-wide config."
         )
+
+    # Surface the full stack detection so multi-language projects (e.g. a Python
+    # backend + Go service + Node frontend) don't get reduced to ``primary_stack``
+    # alone. ``multi_stack`` is a convenience boolean for downstream tools.
+    stack_labels: list[str] = list(context.get("stack_labels", []) or [])
+    multi_stack = len(stack_labels) > 1
+
     return {
         "target_root": str(paths.target_root),
         "kit_root": str(paths.kit_root),
@@ -136,6 +143,9 @@ def build_manifest(
         "project_name": args.project_name,
         "adoption_mode": args.adoption_mode,
         "harnesses": selected_harnesses,
+        "primary_stack": context.get("primary_stack", "unknown"),
+        "stack_labels": stack_labels,
+        "multi_stack": multi_stack,
         "analysis_summary": context.get("analysis_summary", []),
         "generated_files": generated_files,
         "generated_harness_files": harness_files,

--- a/workflow-source/tests/check_bootstrap.py
+++ b/workflow-source/tests/check_bootstrap.py
@@ -503,7 +503,7 @@ def check_enable_mcp_emission() -> None:
             "codex_mcp_config": ".codex/mcp.toml",
             "opencode_mcp_config": "mcp.opencode.json",
             "gemini_cli_mcp_config": ".gemini/mcp.json",
-            "antigravity_mcp_config": "antigravity.mcp.json",
+            "antigravity_mcp_config": ".antigravity/mcp.json",
             "minimax_code_mcp_config": ".MiniMax/mcp.json",
         }
         for key, suffix in expected_keys.items():
@@ -525,6 +525,66 @@ def check_enable_mcp_emission() -> None:
             raise AssertionError("MiniMax MCP config should declare the standardAiWorkflowReadOnly server.")
         if minimax_payload["mcp_servers"]["standardAiWorkflowReadOnly"].get("transport") != "jsonrpc-bridge":
             raise AssertionError("MiniMax MCP config should default to jsonrpc-bridge transport.")
+
+
+def check_multi_stack_detection() -> None:
+    """Cross-language projects (e.g. Python+Go+Node) should expose all stacks."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        target_root = Path(tmpdir) / "multi-stack-repo"
+        target_root.mkdir(parents=True, exist_ok=True)
+        # Create three language indicator files so the scanner sees all three.
+        (target_root / "package.json").write_text(
+            '{"name": "demo", "scripts": {"test": "npm test"}}',
+            encoding="utf-8",
+        )
+        (target_root / "pyproject.toml").write_text(
+            '[project]\nname = "demo"\n', encoding="utf-8"
+        )
+        (target_root / "go.mod").write_text(
+            "module example.com/demo\n\ngo 1.22\n", encoding="utf-8"
+        )
+        (target_root / "docs").mkdir(parents=True, exist_ok=True)
+        (target_root / "tests").mkdir(parents=True, exist_ok=True)
+
+        payload = run_bootstrap(
+            [
+                "--target-root",
+                str(target_root),
+                "--project-slug",
+                "multi_stack_demo",
+                "--project-name",
+                "Multi Stack Demo",
+                "--adoption-mode",
+                "existing",
+                "--harness",
+                "codex",
+                "--copy-core-docs",
+            ]
+        )
+
+        stack_labels = payload.get("stack_labels")
+        if not isinstance(stack_labels, list):
+            raise AssertionError("Manifest should expose stack_labels as a list.")
+        for expected in ("node", "python", "go"):
+            if expected not in stack_labels:
+                raise AssertionError(
+                    f"stack_labels should include {expected!r}, got {stack_labels}"
+                )
+        if not payload.get("multi_stack"):
+            raise AssertionError(
+                f"multi_stack should be True with 3+ stacks, got stack_labels={stack_labels}"
+            )
+
+        # The README/assessment generated for existing mode should mention
+        # multiple stacks so the operator doesn't think it's single-language.
+        assessment_text = Path(str(payload["generated_files"]["repository_assessment"])).read_text(
+            encoding="utf-8"
+        )
+        for expected in ("node", "python", "go"):
+            if expected not in assessment_text:
+                raise AssertionError(
+                    f"Repository assessment should mention stack {expected!r}"
+                )
 
 
 def check_stdio_sdk_mcp_emission() -> None:
@@ -566,6 +626,7 @@ def main() -> int:
     check_antigravity_mode()
     check_minimax_code_mode()
     check_enable_mcp_emission()
+    check_multi_stack_detection()
     check_stdio_sdk_mcp_emission()
     print("Bootstrap scaffold smoke check passed for all modes including gemini-cli, antigravity, minimax-code, and --enable-mcp emission.")
     return 0


### PR DESCRIPTION
## Summary

v0.5.2 의 deferred 2개 항목을 묶어서 처리:

- **TASK-V053-001**: antigravity MCP config 경로를 `antigravity.mcp.json` → `.antigravity/mcp.json` 으로 변경. 다른 3개 하네스(`.codex/`, `.gemini/`, `.MiniMax/`) 와 같은 dot-dir 컨벤션 따름.
- **TASK-V053-002**: cross-language 프로젝트(예: Python+Go+Node)에서도 모든 감지 스택이 manifest / handoff / assessment 에 노출되도록 함.

## TASK-V053-001 상세

### 변경
- `bootstrap_lib/mcp.py:221` — antigravity MCP config 출력 경로 변경
- `bootstrap_lib/mcp.py:140` — docstring 갱신
- `harnesses/antigravity/apply_guide.md` — 4개 참조 갱신
- `core/mcp_installation_by_harness.md` — 2개 참조 갱신
- `tests/check_bootstrap.py:506` — expected suffix 갱신

### 영향
- 사용자가 이미 `antigravity.mcp.json` 을 사용 중이라면 수동으로 `.antigravity/mcp.json` 으로 마이그레이션 필요
- 글로벌 `~/.antigravity/mcp.json` copy 패턴은 동일 (변경 없음)

## TASK-V053-002 상세

### 변경
- `build_manifest` 에 `stack_labels: list[str]` + `multi_stack: bool` 필드 추가
- `render_session_handoff` existing 모드: 다중 스택이면 "all detected stacks: X, Y, Z" 추가
- `check_bootstrap.py` 에 `check_multi_stack_detection` 신규 테스트:
  - 3개 언어 fixture (package.json + pyproject.toml + go.mod)
  - manifest 의 `stack_labels` 에 3개 모두 포함 검증
  - `multi_stack: True` 검증
  - assessment 에 stack 라벨들이 표시되는지 검증

### 실제 출력 예시 (Go+Node+Python fixture)
```json
{
  "primary_stack": "go",
  "stack_labels": ["go", "node", "python"],
  "multi_stack": true
}
```

Handoff: "inferred primary stack: go; all detected stacks: go, node, python"

## Regression

- ✅ `check_bootstrap.py` 8/8 PASS (기존 7 + 신규 multi_stack)
- ✅ `check_bootstrap_mcp_roundtrip.py` 5/5 PASS
- ✅ `check_docs.py` 99/99 PASS
- ✅ Linter status ok (0 issues, 0 broken links)

## Memory layer

`ai-workflow/memory/release/v0.5.3/`:
- `PROJECT_PROFILE.md` (v0.5.3 프로젝트 프로파일)
- `session_handoff.md` (TASK-V053-001/002 in_progress)
- `backlog/2026-06-07.md` (TASK 상세)
- `state.json` (workflow 상태 캐시)