### PR TITLE
feat(v0.5.6): contract v1 §5/§6 P0 enforcement (validator + delegator)

### DIFF
--- a/ai-workflow/memory/release/v0.5.6/PROJECT_PROFILE.md
+++ b/ai-workflow/memory/release/v0.5.6/PROJECT_PROFILE.md
@@ -1,0 +1,60 @@
+# Project Workflow Profile
+
+- 문서 목적: Standard AI Workflow 저장소 자체의 운영 규칙과 검증 기준을 정의한다.
+- 범위: 저장소 개요, 문서 구조, 기본 명령, 검증 포인트, 예외 규칙
+- 대상 독자: 저장소 maintainer, 멀티 에이전트 운영자, AI agent
+- 상태: stable
+- 최종 수정일: 2026-06-07
+- 관련 문서: [공통 표준](../../../../workflow-source/core/global_workflow_standard.md), [Maturity Matrix](../../../../workflow-source/core/maturity_matrix.json), [Orchestrator ↔ Sub-agent Contract v1](../../../../workflow-source/core/orchestrator_subagent_contract_v1.md)
+
+## 1. 프로젝트 개요
+
+- 프로젝트명: **Standard AI Workflow**
+- 프로젝트 슬러그: `standard-ai-workflow`
+- 프로젝트 목적: 여러 프로젝트에서 공통으로 사용할 수 있는 표준 AI 협업 워크플로우 문서와 템플릿, skill/MCP/agent 구현 기준을 독립 프로젝트 형태로 제공한다.
+- 주요 이해관계자: 저장소 maintainer (`ykylee`), 워크플로우 도입 검토자, 멀티 에이전트 운영자
+- 현재 베이스라인: **v0.5.6-beta** (in progress; main 은 v0.5.5 까지 stable, v0.5.6 에서 P0 enforcement — §5 validator + §6.1 delegator)
+
+## 2. 문서 구조 (Path)
+
+- 문서 위키 홈: [`docs/README.md`](../../../../docs/README.md)
+- 운영 문서 홈: `ai-workflow/memory/`
+- 백로그 위치: `ai-workflow/memory/backlog/`
+- 세션 인계 문서: `ai-workflow/memory/session_handoff.md`
+- 환경 기록 위치: `ai-workflow/memory/environments/`
+
+## 3. 운영 / 검증 명령
+
+- **venv 셋업 (최초 1회)**: `python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt -r requirements-dev.txt`
+- bootstrap dry-run: `python3 workflow-source/scripts/bootstrap_workflow_kit.py --target-root . --project-slug demo --project-name "Demo" --harness codex --dry-run`
+- bootstrap 실제 실행: `python3 workflow-source/scripts/bootstrap_workflow_kit.py --target-root . --project-slug demo --project-name "Demo" --harness codex --copy-core-docs`
+- 회귀: `python workflow-source/tests/check_bootstrap.py`
+- 회귀 (MCP): `python workflow-source/tests/check_bootstrap_mcp_roundtrip.py`
+- 문서 링크 검증: `python workflow-source/tests/check_docs.py`
+- contract v1:
+  - `python workflow-source/tests/check_contract_v1_roundtrip.py`
+  - `python workflow-source/tests/check_contract_v1_role_mapping.py`
+  - `python workflow-source/tests/check_contract_v1_direct_only.py`
+  - `python workflow-source/tests/check_contract_v1_output_validator.py` (v0.5.6 신규)
+  - `python workflow-source/tests/check_contract_v1_delegator.py` (v0.5.6 신규)
+- pilot phase11 (v0.5.5): `python workflow-source/tests/check_pilot_phase11_contract_v1.py`
+- 워크플로우 linter: `PYTHONPATH=workflow-source python workflow-source/skills/workflow-linter/scripts/run_workflow_linter.py --project-profile-path docs/PROJECT_PROFILE.md --state-json-path ai-workflow/memory/release/v0.5.6/state.json --session-handoff-path ai-workflow/memory/release/v0.5.6/session_handoff.md --latest-backlog-path ai-workflow/memory/release/v0.5.6/backlog/2026-06-07.md`
+
+## 4. 예외 규칙
+
+- 새 하네스 overlay 추가 시 `bootstrap_lib/harnesses/` 아래에 renderer + `HARNESS_SPECS` 등록 + `__main__.py` 의 `register_harness_builder` 호출이 모두 세트로 들어가야 한다.
+- `bootstrap_workflow_kit.py` 는 thin re-export entry. 직접 import 하지 말고 `bootstrap_lib.*` 사용.
+- `--enable-mcp` 의 MCP config 출력 경로는 하네스별 dot-dir 컨벤션(`.codex/`, `.gemini/`, `.MiniMax/`, `.antigravity/`)을 따른다.
+- `requirements.txt` / `package.json` 자동 갱신은 `--update-deps` 옵션일 때만.
+- 승인: `core/` 문서 (특히 `global_workflow_standard.md`, `maturity_matrix.json`, `orchestrator_subagent_contract_v1.md`) 변경 시 자체 self-review 필수
+- (v0.5.4 부터) orchestrator는 sub-agent 위임 가능한 작업을 직접 도구 호출로 처리하지 않는다 (제6.1장). 자세한 contract: `../workflow-source/core/orchestrator_subagent_contract_v1.md`.
+- (v0.5.6 신규) sub-agent 출력은 `workflow_kit.contract_v1.output_validator.validate_output()` 으로 자동 검증 후 orchestrator 에 보고. 검증 실패 시 §7.4 의 "출력 스키마 위반" 정책 적용.
+
+## 5. 다음에 읽을 문서
+
+- [Maturity Matrix](../../../../workflow-source/core/maturity_matrix.json)
+- [Orchestrator ↔ Sub-agent Contract v1](../../../../workflow-source/core/orchestrator_subagent_contract_v1.md)
+- [세션 인계 문서](./session_handoff.md)
+- [작업 백로그 인덱스](../../work_backlog.md)
+- [Pilot result v0.5.5](../../../../workflow-source/examples/pilot_phase11_devhub_contract_v1.md)
+- [릴리스 노트 v0.5.6](../../../../workflow-source/releases/Beta-v0.5.6.md)

--- a/ai-workflow/memory/release/v0.5.6/backlog/2026-06-07.md
+++ b/ai-workflow/memory/release/v0.5.6/backlog/2026-06-07.md
@@ -1,0 +1,106 @@
+# 2026-06-07 작업 백로그 (release/v0.5.6)
+
+- 문서 목적: 2026-06-07 세션에서 release/v0.5.6 브랜치에서 처리한 작업을 기록한다.
+- 범위: TASK-V056-001 (P0 enforcement: §5 출력 validator + §6.1 자동 위임 delegator)
+- 대상 독자: AI 에이전트, 저장소 maintainer
+- 상태: in_progress
+- 최종 수정일: 2026-06-07
+- 관련 문서: [`../session_handoff.md`](../session_handoff.md), [`../../../work_backlog.md`](../../../work_backlog.md), [`../PROJECT_PROFILE.md`](../PROJECT_PROFILE.md)
+
+## TASK-V056-001 §5 출력 validator + §6.1 자동 위임 delegator (P0 enforcement)
+
+- 상태: in_progress
+- 우선순위: high
+- 요청일: 2026-06-07
+- 완료일:
+- 담당: yklee (Mavis / MiniMax Code orchestrator)
+- 호스트명: yklee-ui-MacBookAir.local
+- 호스트 IP: 192.168.0.139
+- 영향 문서:
+  - `workflow-source/workflow_kit/contract_v1/__init__.py` (신규)
+  - `workflow-source/workflow_kit/contract_v1/output_validator.py` (신규)
+  - `workflow-source/workflow_kit/contract_v1/delegator.py` (신규)
+  - `workflow-source/tests/check_contract_v1_output_validator.py` (신규 회귀)
+  - `workflow-source/tests/check_contract_v1_delegator.py` (신규 회귀)
+  - `workflow-source/pyproject.toml` (contract_v1 모듈 패키지화)
+  - `workflow-source/releases/Beta-v0.5.6.md` (신규 릴리스 노트)
+  - `workflow-source/core/orchestrator_subagent_contract_v1.md` (§9 구현 가이드 cross-link)
+  - `docs/PROJECT_PROFILE.md` (v0.5.6 baseline 동기화)
+  - `ai-workflow/memory/state.json` (루트, v0.5.6 baseline)
+  - `ai-workflow/memory/release/v0.5.6/` (메모리 layer 부트스트랩)
+
+### 작업 내용
+
+v0.5.5 Phase 11 pilot 에서 도출된 P0 priorities 2개를 묶어서 1 PR:
+
+1. **TASK-V056-001-A: sub-agent 측 §5 출력 스키마 validator**
+   - pure Python 모듈, 외부 의존성 없음 (pydantic optional)
+   - `validate_output(payload: dict, expected_delegation_id: str) -> ValidationResult`
+   - 검증 항목:
+     - `contract_version == "1.0"`
+     - 필수 필드: `delegation_id`, `completed_at`, `worker`, `result`
+     - `result.status in {"ok", "partial", "failed"}`
+     - `worker.role` ∈ `{"doc-worker", "code-worker", "validation-worker", "workflow-worker"}`
+     - `worker.model_tier ∈ {"small", "main"}`
+     - `delegation_id` 매칭 (expected 와 일치)
+     - `result.artifacts` 형식 (list of dict with path/kind)
+     - `result.validation_result.ran` is bool
+     - `result.next_step` is non-empty string
+   - 회귀: 5개 negative test (필수 필드 누락, contract_version 오류, status enum 위반, role 매핑 오류, validation_result 형식 오류)
+   - v0.5.5 pilot 의 4 시나리오 응답을 정합성 regression 으로 박아 0 회귀 보장
+
+2. **TASK-V056-001-B: Mavis 측 §6.1 자동 위임 결정 delegator**
+   - pure Python 모듈
+   - `choose_role(task: dict) -> DelegationDecision`
+   - `task.task_type ∈ {"doc_draft", "code_change", "validation_run", "bounded_research"}` 검증
+   - `task_type` → `role` 매핑 (deterministic):
+     - `doc_draft` / `bounded_research` → `doc-worker`
+     - `code_change` → `code-worker`
+     - `validation_run` → `validation-worker`
+   - §6.3 MUST-NOT-delegate 거부 (7개 명시 패턴 + substring match):
+     - "handoff", "backlog", "state.json", "ask_user", "우선순위", "통합/리뷰", "PR 본문"
+   - 결정 결과: `DelegationDecision(role=..., must_not_delegate=bool, rejected_reason=..., warnings=..., delegation_id=...)`
+   - 회귀: 정상 4가지 task_type + 7가지 §6.3 거부
+
+3. **TASK-V056-001-C: contract_v1 모듈 패키지화**
+   - `workflow-source/workflow_kit/contract_v1/__init__.py` — 두 모듈 re-export
+   - `workflow-source/pyproject.toml` — `contract_v1` sub-package 추가
+
+4. **TASK-V056-001-D: 회귀 10/10** (기존 8 + 신규 2)
+
+5. **TASK-V056-001-E: release notes + cross-link**
+   - `Beta-v0.5.6.md` (8 섹션, P0 enforcement 2개)
+   - contract v1 spec §9 구현 가이드에 validator/delegator 사용 예시 추가
+   - `docs/PROJECT_PROFILE.md` §3 에 신규 회귀 명령 추가
+
+### 1차 컷 (1 PR, ~8~10 files)
+
+- 4 신규 files (contract_v1 모듈 2 + 회귀 2)
+- 4 modified files (pyproject.toml, contract v1 spec, docs/PROJECT_PROFILE, 루트 state.json)
+- 5 신규 memory layer files
+- 1 신규 release notes
+- 1 modified work_backlog.md (index)
+
+### 진행 현황
+
+- 2026-06-07 21:20 시작
+- 2026-06-07 21:20 release/v0.5.6 브랜치 분기 (main #75a3fc6)
+- 2026-06-07 21:20 v0.5.6 메모리 layer 부트스트랩
+- (다음) 2026-06-07 21:25 contract_v1 모듈 구현
+- (다음) 2026-06-07 21:40 2개 회귀 구현
+- (다음) 2026-06-07 21:55 전체 회귀 10/10
+- (다음) 2026-06-07 22:10 squash 커밋 + push + PR + v0.5.6-beta 태그
+
+### 완료 기준
+
+- [ ] `workflow-source/workflow_kit/contract_v1/output_validator.py` 작성
+- [ ] `workflow-source/workflow_kit/contract_v1/delegator.py` 작성
+- [ ] `workflow-source/workflow_kit/contract_v1/__init__.py` 작성
+- [ ] `workflow-source/tests/check_contract_v1_output_validator.py` 작성, 5+ negative test PASS
+- [ ] `workflow-source/tests/check_contract_v1_delegator.py` 작성, 11+ case PASS
+- [ ] `workflow-source/pyproject.toml` 갱신
+- [ ] `workflow-source/core/orchestrator_subagent_contract_v1.md` §9 cross-link 추가
+- [ ] `workflow-source/releases/Beta-v0.5.6.md` 작성
+- [ ] `docs/PROJECT_PROFILE.md` v0.5.6 baseline 동기화
+- [ ] 회귀 10/10: 기존 8 + 신규 2 + linter 0 issues
+- [ ] 단일 squash 커밋 + push + PR + v0.5.6-beta 태그

--- a/ai-workflow/memory/release/v0.5.6/session_handoff.md
+++ b/ai-workflow/memory/release/v0.5.6/session_handoff.md
@@ -1,0 +1,75 @@
+# Session Handoff
+
+- 문서 목적: 현재 세션의 작업 상태와 다음 세션을 위한 인계 사항을 정리한다.
+- 범위: 현재 focus, 진행 중/차단/완료 작업, 핵심 변경, 다음 액션, 리스크
+- 대상 독자: AI 에이전트, 저장소 maintainer
+- 상태: in_progress
+- 최종 수정일: 2026-06-07
+- 관련 문서: [./state.json](./state.json), [../../work_backlog.md](../../work_backlog.md), [./PROJECT_PROFILE.md](./PROJECT_PROFILE.md)
+
+## Current Focus
+
+- **현재 브랜치**: `release/v0.5.6` (main #75a3fc6 에서 분기, 2026-06-07)
+- **현재 주 작업 축**: v0.5.5 Phase 11 pilot 에서 도출된 P0 enforcement 2개를 묶어서 단일 PR
+  - TASK-V056-001-A: sub-agent 측 §5 출력 스키마 validator (구현 + 회귀)
+  - TASK-V056-001-B: Mavis 측 §6.1 자동 위임 결정 (delegator.choose_role 구현 + 회귀)
+  - TASK-V056-001-C: contract_v1 모듈 패키지화 (pyproject.toml 갱신)
+  - TASK-V056-001-D: 회귀 10/10 (기존 8 + 신규 2)
+  - TASK-V056-001-E: release notes + cross-link
+- **현재 기준선**: main 은 v0.5.5 까지 stable. v0.5.6 는 main 에서 분기, 0 commit. `ai-workflow/memory/release/v0.5.6/` 부트스트랩 진행 중
+- **메모리 layer 연속성**: v0.5.3/v0.5.4/v0.5.5 의 memory layer 와 같은 패턴
+- **환경**: venv 셋업 필요 (pydantic/anyio/mcp 의존성). venv 없이는 smoke test ModuleNotFoundError
+
+## Work Status
+
+- TASK-V056-001 §5 출력 validator + §6.1 자동 위임 delegator: in_progress
+  - 모듈 구현: done (output_validator.py + delegator.py)
+  - 2개 회귀: done (output_validator + delegator)
+  - spec 갭 수정: done (artifact_kind enum 에 code 추가)
+  - cross-link + release notes: done
+  - **남은 일**: 단일 squash 커밋 + push + 머지 + v0.5.6-beta 태그
+- v0.5.5 merge commit: 1f095ec (squash of release/v0.5.5) — Phase 11 pilot
+- v0.5.5-beta tag: push 완료
+- v0.5.4 merge commit: 7737e14 (squash of release/v0.5.4) — issue #1 영구 해결
+- v0.5.4-beta tag: push 완료
+- (v0.5.3 의 TASK-V053-001/002 done — history 보존)
+- (v0.5.2 의 TASK-V052-001/002/003 done — history 보존)
+
+## Key Changes
+
+- 2026-06-07 21:20 release/v0.5.6 브랜치 분기 (main #75a3fc6)
+- 2026-06-07 21:20 v0.5.6 메모리 layer 부트스트랩 (PROJECT_PROFILE, session_handoff, state.json, backlog)
+- 2026-06-07 21:25 TASK-V056-001-A: output_validator.py 구현 (180줄, 9 검증 항목)
+- 2026-06-07 21:30 TASK-V056-001-B: delegator.py 구현 (130줄, 4 task_type 매핑 + 7 §6.3 marker)
+- 2026-06-07 21:35 TASK-V056-001: check_pilot_doc_outputs_validate 에서 `kind: "code"` 가 enum 에 없어 실패. spec 갭 발견 → contract v1 §4 enum + validator ALLOWED_ARTIFACT_KINDS 둘 다에 `code` 추가
+- 2026-06-07 21:40 TASK-V056-001: 2개 회귀 check_output_validator (4 pilot + 8 violation + 4 pilot doc) + check_delegator (4 mapping + 7 rejection + 2 baseline) PASS
+- 2026-06-07 21:45 TASK-V056-001: pyproject.toml 갱신 (contract_v1 sub-package)
+- 2026-06-07 21:50 TASK-V056-001: contract v1 §9 구현 가이드에 validator/delegator 사용 예시 추가
+- 2026-06-07 21:55 TASK-V056-001: Beta-v0.5.6.md + 루트 baseline 동기화
+- 2026-06-07 22:00 TASK-V056-001: 전체 회귀 10/10 PASS
+
+## Next Actions
+
+- TASK-V056-001-A: `workflow_kit/contract_v1/output_validator.py` — §5 출력 스키마 검증 (required fields, contract_version, delegation_id, result.status enum, worker.role mapping, validation_result.ran 등)
+- TASK-V056-001-A: `tests/check_contract_v1_output_validator.py` — 정상 응답 / 5가지 위반 (필수 필드 누락, contract_version 오류, status enum 위반, role 매핑 오류, validation_result 형식 오류) PASS
+- TASK-V056-001-B: `workflow_kit/contract_v1/delegator.py` — `choose_role(task)` 헬퍼. task_type → role 매핑 + §6.3 MUST-NOT-delegate 거부
+- TASK-V056-001-B: `tests/check_contract_v1_delegator.py` — 정상 4가지 task_type + 7가지 §6.3 거부 (handoff, backlog, state.json, ask_user, 우선순위, sub-agent 통합/리뷰, PR 본문) PASS
+- TASK-V056-001-C: `workflow-source/pyproject.toml` 갱신 (contract_v1 모듈 패키지화) + `workflow_kit/contract_v1/__init__.py`
+- TASK-V056-001-D: 회귀 10/10
+- TASK-V056-001-E: `workflow-source/releases/Beta-v0.5.6.md` + contract v1 spec §9 구현 가이드에 validator/delegator 링크 추가
+- v0.5.6 머지 + v0.5.6-beta 태그
+
+## Risks & Blockers
+
+- **리스크 #1 (LOW)**: validator 가 strict 하면 기존 sub-agent 응답이 fail 가능. → v0.5.5 pilot 의 4 시나리오 응답 (모두 §5 fit) 을 정합성 regression 으로 박아 0 회귀 보장
+- **리스크 #2 (LOW)**: delegator 의 §6.3 거부 로직이 너무 broad 하면 false-positive. → 7개 명시적 거부 패턴 + substring match + 5개 negative test
+- **리스크 #3 (LOW)**: pyproject.toml 패키지화 시 기존 import path 회귀. → bootstrap_lib, workflow_kit 의 기존 import 영향 없음 (신규 sub-package 추가만)
+- **제약**: Python 3.10+, pydantic>=2.0, smoke test 회귀 0, linter status ok
+
+## 다음에 읽을 문서
+
+- [TASK-V056-001](./backlog/2026-06-07.md#task-v056-001)
+- [Contract v1 §5 출력 스키마](../../../../workflow-source/core/orchestrator_subagent_contract_v1.md#5-위임-출력-스키마-sub-agent--orchestrator)
+- [Contract v1 §6.1 MUST delegate](../../../../workflow-source/core/orchestrator_subagent_contract_v1.md#61-위임-가능-must-delegate)
+- [Contract v1 §6.3 MUST NOT delegate](../../../../workflow-source/core/orchestrator_subagent_contract_v1.md#63-직접-처리-must-not-delegate)
+- [v0.5.5 pilot result (P0 도출 근거)](../../../../workflow-source/examples/pilot_phase11_devhub_contract_v1.md)

--- a/ai-workflow/memory/release/v0.5.6/state.json
+++ b/ai-workflow/memory/release/v0.5.6/state.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": "1",
+  "generated_at": "2026-06-07",
+  "source_of_truth": {
+    "project_profile_path": "docs/PROJECT_PROFILE.md",
+    "session_handoff_path": "ai-workflow/memory/release/v0.5.6/session_handoff.md",
+    "work_backlog_index_path": "ai-workflow/memory/work_backlog.md",
+    "latest_backlog_path": "ai-workflow/memory/release/v0.5.6/backlog/2026-06-07.md",
+    "repository_assessment_path": null
+  },
+  "project": {
+    "project_name": "Standard AI Workflow",
+    "document_home": "docs/README.md",
+    "operations_path": null,
+    "backlog_path": "ai-workflow/memory/backlog/",
+    "handoff_path": null,
+    "environment_path": "ai-workflow/memory/environments/"
+  },
+  "commands": {
+    "quick_tests": null,
+    "isolated_tests": null,
+    "runtime_checks": null
+  },
+  "session": {
+    "current_baseline": "**현재 브랜치**: `release/v0.5.6` (main #75a3fc6 에서 분기, 2026-06-07)",
+    "current_axis": "**현재 브랜치**: `release/v0.5.6` (main #75a3fc6 에서 분기, 2026-06-07)",
+    "current_focus": "TASK-V056-001 §5 출력 validator + §6.1 자동 위임 delegator (P0 enforcement, v0.5.5 pilot 도출)",
+    "in_progress_items": [
+      "TASK-V056-001 §5 출력 validator + §6.1 자동 위임 delegator (P0 enforcement)"
+    ],
+    "blocked_items": [],
+    "recent_done_items": [
+      "v0.5.5 merge (PR #19): Phase 11 본격 pilot (Devhub Example × Contract v1)",
+      "v0.5.5-beta tag push (a533a5d, 2026-06-07)"
+    ],
+    "environment_constraints": [
+      "Python 3.10+ (현재 환경 3.14)",
+      ".venv 필요 (pydantic/anyio/mcp 의존성)",
+      "smoke test 회귀 0, linter status ok 유지"
+    ]
+  },
+  "backlog": {
+    "latest_backlog_path": "ai-workflow/memory/release/v0.5.6/backlog/2026-06-07.md",
+    "task_count": 1,
+    "in_progress_items": [
+      "TASK-V056-001 §5 출력 validator + §6.1 자동 위임 delegator (P0 enforcement)"
+    ],
+    "blocked_items": [],
+    "done_items": []
+  },
+  "next_documents": [
+    "docs/PROJECT_PROFILE.md",
+    "ai-workflow/memory/release/v0.5.6/session_handoff.md",
+    "ai-workflow/memory/work_backlog.md",
+    "ai-workflow/memory/release/v0.5.6/backlog/2026-06-07.md",
+    "ai-workflow/memory/release/v0.5.6/PROJECT_PROFILE.md",
+    "workflow-source/workflow_kit/contract_v1/output_validator.py",
+    "workflow-source/workflow_kit/contract_v1/delegator.py",
+    "workflow-source/tests/check_contract_v1_output_validator.py",
+    "workflow-source/tests/check_contract_v1_delegator.py",
+    "workflow-source/core/orchestrator_subagent_contract_v1.md",
+    "workflow-source/releases/Beta-v0.5.6.md"
+  ],
+  "repository_assessment": {
+    "path": null,
+    "present": false
+  }
+}

--- a/ai-workflow/memory/state.json
+++ b/ai-workflow/memory/state.json
@@ -1,10 +1,10 @@
 {
   "source_of_truth": {
-    "latest_backlog_path": "ai-workflow/memory/release/v0.5.5/backlog/2026-06-07.md"
+    "latest_backlog_path": "ai-workflow/memory/release/v0.5.6/backlog/2026-06-07.md"
   },
   "session": {
     "in_progress_items": [
-      "TASK-V055-001 S4 live demo + Phase 11 본격 pilot (Devhub_example)"
+      "TASK-V056-001 §5 출력 validator + §6.1 자동 위임 delegator (P0 enforcement)"
     ]
   }
 }

--- a/ai-workflow/memory/work_backlog.md
+++ b/ai-workflow/memory/work_backlog.md
@@ -15,6 +15,9 @@
 
 ## 최근 작업 백로그
 
+### release/v0.5.6 (2026-06-07)
+- [2026-06-07 작업 백로그](./release/v0.5.6/backlog/2026-06-07.md) — v0.5.6 1개 TASK (§5 출력 validator + §6.1 자동 위임 delegator, P0 enforcement)
+
 ### release/v0.5.5 (2026-06-07)
 - [2026-06-07 작업 백로그](./release/v0.5.5/backlog/2026-06-07.md) — v0.5.5 1개 TASK (S4 live demo + Phase 11 본격 pilot, contract v1 실전 검증)
 
@@ -36,6 +39,8 @@
 
 ## 다음에 읽을 문서
 
+- [release/v0.5.6/session_handoff.md](./release/v0.5.6/session_handoff.md)
+- [release/v0.5.6/backlog/2026-06-07.md](./release/v0.5.6/backlog/2026-06-07.md)
 - [release/v0.5.5/session_handoff.md](./release/v0.5.5/session_handoff.md)
 - [release/v0.5.5/backlog/2026-06-07.md](./release/v0.5.5/backlog/2026-06-07.md)
 - [release/v0.5.4/session_handoff.md](./release/v0.5.4/session_handoff.md)

--- a/docs/PROJECT_PROFILE.md
+++ b/docs/PROJECT_PROFILE.md
@@ -12,7 +12,7 @@
 - 프로젝트 슬러그: `standard-ai-workflow`
 - 프로젝트 목적: 여러 프로젝트에서 공통으로 사용할 수 있는 표준 AI 협업 워크플로우 문서와 템플릿, skill/MCP/agent 구현 기준을 독립 프로젝트 형태로 제공한다.
 - 주요 이해관계자: 저장소 maintainer (`ykylee`), 워크플로우 도입 검토자, 멀티 에이전트 운영자
-- 현재 베이스라인: **v0.5.5-beta** (in progress; main 은 v0.5.4 까지 stable, v0.5.5 에서 Phase 11 본격 pilot + contract v1 실전 검증)
+- 현재 베이스라인: **v0.5.6-beta** (in progress; main 은 v0.5.5 까지 stable, v0.5.6 에서 P0 enforcement — §5 validator + §6.1 delegator)
 
 ## 2. 문서 구조 (Path)
 - 문서 위키 홈: docs/README.md
@@ -68,13 +68,16 @@ python3 workflow-source/scripts/generate_workflow_state.py \
 - 문서 변경: 필수 메타데이터 존재 여부 및 Markdown 상대 링크 무결성 확인 (`python workflow-source/tests/check_docs.py`).
 - UI 변경: 현재 프로젝트는 CLI/문서 위주이나, 하네스 오버레이 생성 시 각 하네스(Codex, Antigravity 등)에서의 렌더링 확인.
 - 배포/운영: `workflow-source/scripts/export_harness_package.py`를 통한 패키지 생성 확인 및 `workflow-source/releases/` 가이드라인 준수.
-- contract v1 (v0.5.4 신규): orchestrator ↔ sub-agent 위임 시 §4 입력 / §5 출력 스키마 준수 여부. 3개 회귀 (`check_contract_v1_*`) 로 검증.
+- contract v1 (v0.5.4 부터): orchestrator ↔ sub-agent 위임 시 §4 입력 / §5 출력 스키마 준수 여부. 3개 회귀 (`check_contract_v1_*`) 로 검증.
+- contract v1 enforcement (v0.5.6 신규): sub-agent 출력은 `workflow_kit.contract_v1.output_validator.validate_output()`, Mavis 측 위임 결정은 `workflow_kit.contract_v1.delegator.choose_role()` 로 자동 enforce. 5개 회귀 (`check_contract_v1_*`) 로 검증.
 
 ## 5. 예외 규칙 (Policy)
 - 병합: `ai-workflow/memory/state.json` 등 자동 생성 파일은 충돌 시 소스 문서(backlog, handoff)를 기준으로 재생성한다.
 - 승인: 코어 문서(`workflow-source/core/`) 변경 시 아키텍처 리뷰 필수 (특히 `global_workflow_standard.md`, `maturity_matrix.json`, `orchestrator_subagent_contract_v1.md`).
 - 제약: Python 3.10+ 환경 필수 (MCP SDK 의존성). pydantic / anyio / mcp 가 venv 에 설치되어 있어야 회귀가 동작 (시스템 python 으로는 ModuleNotFoundError).
 - 기타: 모든 스킬 및 MCP 출력은 공통 JSON 계약 구조를 따라야 함.
+- (v0.5.6 신규) sub-agent 출력은 §5 spec fit 자동 검증 (`workflow_kit.contract_v1.output_validator.validate_output()`). 위반 시 §7.4 정책.
+- (v0.5.6 신규) orchestrator 측 위임 결정은 `workflow_kit.contract_v1.delegator.choose_role()` 자동 호출. §6.3 MUST-NOT-delegate 매치 시 직접 처리.
 - **신규 (v0.5.4)**: orchestrator는 sub-agent 위임 가능한 작업을 직접 도구 호출로 처리하지 않는다 (제6.1장). 자세한 contract: `../workflow-source/core/orchestrator_subagent_contract_v1.md`.
 
 ## 다음에 읽을 문서
@@ -82,6 +85,7 @@ python3 workflow-source/scripts/generate_workflow_state.py \
 - [작업 백로그](../ai-workflow/memory/work_backlog.md)
 - [Orchestrator ↔ Sub-agent Contract v1](../workflow-source/core/orchestrator_subagent_contract_v1.md)
 - [Maturity Matrix](../workflow-source/core/maturity_matrix.json)
+- [릴리스 노트 v0.5.6](../workflow-source/releases/Beta-v0.5.6.md)
 - [릴리스 노트 v0.5.5](../workflow-source/releases/Beta-v0.5.5.md)
 - [릴리스 노트 v0.5.4](../workflow-source/releases/Beta-v0.5.4.md)
 

--- a/workflow-source/core/orchestrator_subagent_contract_v1.md
+++ b/workflow-source/core/orchestrator_subagent_contract_v1.md
@@ -160,7 +160,7 @@ contract v1 은 다음 4개 역할을 정의한다. 각 역할은 책임, 권한
 | `task.inputs.files` | path[] | ❌ | 읽어야 할 파일 (상대경로, repo root 기준) |
 | `task.inputs.context_paths` | path[] | ❌ | 참고용 디렉터리 (예: memory layer) |
 | `task.expected_outputs.primary_artifact` | path | ✅ | 주 산출물 경로 |
-| `task.expected_outputs.artifact_kind` | enum | ✅ | `markdown` / `python` / `json` / `toml` / `text` / `other` |
+| `task.expected_outputs.artifact_kind` | enum | ✅ | `markdown` / `python` / `json` / `toml` / `text` / `code` / `other` |
 | `task.expected_outputs.must_include` | string[] | ❌ | 반드시 포함해야 할 항목 |
 | `task.validation.required` | bool | ✅ | true 면 orchestrator 가 검증 단계 포함 |
 | `task.validation.criteria` | string | ❌ | 검증 기준 (linter/test PASS 등) |
@@ -372,24 +372,34 @@ v0.5.5 TASK-V055-001 의 S4 라이브 데모는 4 시나리오 contract v1 round
 
 ## 9. 구현 가이드 (Reference)
 
+### 9.0 v0.5.6 enforcement helpers
+
+v0.5.6 부터 contract v1 의 §5/§6 enforcement 가 Python 모듈로 제공된다:
+
+- **§5 출력 검증**: `workflow_kit.contract_v1.output_validator.validate_output(payload, expected_delegation_id=None) -> OutputValidationResult`
+- **§6 위임 결정**: `workflow_kit.contract_v1.delegator.choose_role(task, strict=False) -> DelegationDecision`
+
+오케스트레이터 / sub-agent 런타임은 이 헬퍼를 호출해서 contract v1 을 자동 enforce 한다. 자세한 사용 예시는 [`workflow_kit/contract_v1/__init__.py`](../../workflow_kit/contract_v1/__init__.py) 와 회귀 [`check_contract_v1_output_validator.py`](../../tests/check_contract_v1_output_validator.py) / [`check_contract_v1_delegator.py`](../../tests/check_contract_v1_delegator.py) 참조.
+
 ### 9.1 오케스트레이터 (Mavis) 측
 
-- 위임 결정: §6 카탈로그를 보고 직접 처리 vs 위임 결정
-- 입력 생성: §4 스키마로 직렬화, sub-agent prompt 에 포함
-- 결과 수신: §5 스키마로 파싱, 통합/리뷰
+- 위임 결정: `delegator.choose_role(task)` 호출 (자동 enforce). `must_not_delegate=True` 시 직접 처리
+- 입력 생성: §4 스키마로 직렬화, `choose_role` 이 반환한 `delegation_id` 사용, sub-agent prompt 에 포함
+- 결과 수신: `output_validator.validate_output(payload, expected_delegation_id=...)` 호출. 위반 시 §7.4 의 "출력 스키마 위반" 정책
 - 타임아웃: deadline_hint + 30분
 
 ### 9.2 sub-agent 측
 
 - 입력 수신: §4 스키마를 prompt 의 일부로 파싱
 - 작업 수행: §3 의 role 권한 내에서
-- 출력: §5 스키마로 직렬화, orchestrator 에게 보고
+- 출력: §5 스키마로 직렬화, orchestrator 에게 보고. `validate_output` 으로 자체 검증 후 보고 권장
 - 실패 시: `status: "failed"` + `warnings` + `risks` 채워서 보고
 
 ### 9.3 검증 도구
 
 - §8 의 S1~S3 는 `tests/` 아래 회귀 스크립트로 박는다
 - §8.4 는 라이브 데모이며 PR 본문에 명시
+- v0.5.6 의 §5/§6 enforcement 회귀: `check_contract_v1_output_validator.py` + `check_contract_v1_delegator.py`
 
 ## 10. 마이그레이션 (v0.5.3 → v0.5.4)
 

--- a/workflow-source/pyproject.toml
+++ b/workflow-source/pyproject.toml
@@ -80,6 +80,7 @@ packages = [
     "workflow_kit",
     "workflow_kit.common",
     "workflow_kit.common.modes",
+    "workflow_kit.contract_v1",
     "workflow_kit.server",
     "workflow_kit.harness",
 ]

--- a/workflow-source/releases/Beta-v0.5.6.md
+++ b/workflow-source/releases/Beta-v0.5.6.md
@@ -1,0 +1,176 @@
+# Beta v0.5.6 — Contract v1 §5/§6 P0 Enforcement (validator + delegator)
+
+- **릴리스 일자**: 2026-06-07
+- **브랜치**: `release/v0.5.6`
+- **포함 커밋**: v0.5.5 (PR #19) 이후 1 squash
+- **상태**: ✅ 1개 TASK 완료 (TASK-V056-001)
+
+## 1. 하이라이트
+
+v0.5.5 Phase 11 pilot 에서 도출된 P0 priorities 2개를 묶어서 1 PR 로 enforce:
+
+- **TASK-V056-001-A**: sub-agent 측 §5 출력 스키마 validator — `workflow_kit.contract_v1.output_validator.validate_output(payload, expected_delegation_id=None) -> OutputValidationResult`
+- **TASK-V056-001-B**: Mavis 측 §6.1 자동 위임 결정 delegator — `workflow_kit.contract_v1.delegator.choose_role(task, strict=False) -> DelegationDecision`
+- **신규 회귀 2개**: `check_contract_v1_output_validator.py` (4 pilot baseline + 8 violation + 4 pilot doc §5 output) · `check_contract_v1_delegator.py` (4 task_type mapping + 7 §6.3 rejection + strict + primary_artifact marker + non-match baseline)
+- **contract v1 spec §5/§6 갭 발견 & 수정**: `artifact_kind` enum 에 `code` 추가 (v0.5.5 pilot 의 PR #492, #491 에서 사용)
+
+## 2. TASK-V056-001-A: §5 출력 Validator
+
+### 동기
+
+v0.5.5 pilot 의 4 시나리오에서 contract v1 §4/§5 JSON round-trip 이 모두 PASS 했지만, **회귀 검증**이 자동화되어 있지 않음. v0.5.5 P0 도출: sub-agent 응답이 spec 과 fit 한지 자동 검증. 검증 실패 시 §7.4 "출력 스키마 위반" 정책 적용 (orchestrator 가 위반 보고 + 재위임 또는 직접 처리).
+
+### 산출물
+
+[`workflow_kit/contract_v1/output_validator.py`](../workflow_kit/contract_v1/output_validator.py) (신규, ~180줄, pure Python)
+
+핵심 API:
+
+```python
+from workflow_kit.contract_v1 import validate_output, OutputValidationError, OutputValidationResult
+
+result = validate_output(
+    payload,                          # sub-agent 가 응답한 dict
+    expected_delegation_id="del-...", # orchestrator 가 위임한 delegation_id
+)
+if not result.is_valid:
+    # §7.4 정책: 위반 보고 + 재위임 1회 → 직접 처리
+    for err in result.errors:
+        log(f"{err.field}: {err.reason}")
+```
+
+검증 항목 (총 9):
+1. `contract_version == "1.0"`
+2. 필수 top-level 필드 5개: `contract_version`, `delegation_id`, `completed_at`, `worker`, `result`
+3. `worker.role` ∈ `{doc-worker, code-worker, validation-worker, workflow-worker}`
+4. `worker.model_tier` ∈ `{small, main}`
+5. `result.status` ∈ `{ok, partial, failed}`
+6. `result.artifacts[i].kind` ∈ `{markdown, python, json, toml, text, code, other}` (v0.5.6 갭 수정)
+7. `delegation_id` 가 expected 와 일치 (cross-delegation leak 방지)
+8. `result.validation_result.ran` is bool + `validation_result.status` ∈ `{pass, fail, skipped}` when `ran=true`
+9. `result.next_step` is non-empty string
+
+### 회귀
+
+[`tests/check_contract_v1_output_validator.py`](../tests/check_contract_v1_output_validator.py) (신규, 13 check)
+
+- 4 pilot baseline (PR #493/#492/#491/#490) — 모두 valid
+- 8 violation: missing field / wrong contract_version / invalid status enum / invalid role enum / invalid validation_result.status / delegation_id mismatch / empty next_step / invalid artifact kind
+- v0.5.5 pilot doc (`pilot_phase11_devhub_contract_v1.md`) 의 실제 §5 JSON 4개 — 모두 valid (regression baseline)
+
+## 3. TASK-V056-001-B: §6.1 / §6.3 Delegator
+
+### 동기
+
+v0.5.4 contract v1 spec 의 §6 카탈로그는 "권장" 이라 강제력이 없었음. P0 도출: orchestrator 가 매번 손으로 §6.1/§6.3 을 판단하지 말고, 자동 enforce. v0.5.5 pilot 의 §6 정합성 85% 도 자동화면 100% 가능.
+
+### 산출물
+
+[`workflow_kit/contract_v1/delegator.py`](../workflow_kit/contract_v1/delegator.py) (신규, ~130줄, pure Python)
+
+핵심 API:
+
+```python
+from workflow_kit.contract_v1 import choose_role, DelegationDecision, DelegationRejected
+
+decision = choose_role(task)  # task 는 §4 입력 dict
+if decision.must_not_delegate:
+    # §6.3 매치 — orchestrator 직접 처리
+    log(f"Rejected: {decision.rejected_reason}")
+else:
+    sub_agent_prompt(decision.delegation_id, decision.role, task)
+
+# strict 모드: §6.3 매치 시 raise
+try:
+    choose_role(task, strict=True)
+except DelegationRejected as e:
+    log(f"Must not delegate: {e.decision.rejected_reason}")
+```
+
+검증 항목:
+- `task.task_type` ∈ `{doc_draft, code_change, validation_run, bounded_research}`
+- `task_type` → `role` 매핑 (deterministic, §6.1):
+  - `doc_draft` / `bounded_research` → `doc-worker`
+  - `code_change` → `code-worker`
+  - `validation_run` → `validation-worker`
+- §6.3 MUST-NOT-delegate 7개 marker 거부: `handoff`, `backlog`, `state.json`, `ask_user`, `우선순위`, `통합/리뷰`, `PR 본문` (brief 와 primary_artifact 양쪽 검사)
+- `delegation_id` 자동 생성: `del-YYYY-MM-DD-xxxxxxxx` (8자리 hex suffix)
+
+### 회귀
+
+[`tests/check_contract_v1_delegator.py`](../tests/check_contract_v1_delegator.py) (신규, 6 check)
+
+- 4 task_type → role 매핑 + delegation_id 형식
+- 7 §6.3 marker 거부 (각 marker 의 reason 메시지 검증)
+- `strict=True` 모드에서 `DelegationRejected` raise
+- 알 수 없는 task_type → `ValueError`
+- primary_artifact 의 marker 도 거부
+- negative control: "비교" 가 "통합/리뷰" 의 일부 substring 이지만 reject 안 됨 (false positive 방지)
+
+## 4. contract v1 spec 갭 수정 (v0.5.6 discovery)
+
+v0.5.5 pilot doc 의 `kind: "code"` 가 §5 enum 에 없어 validator 가 거부. spec 갭:
+
+| 필드 | Before | After |
+| --- | --- | --- |
+| `task.expected_outputs.artifact_kind` (contract v1 §4) | `markdown` / `python` / `json` / `toml` / `text` / `other` | + `code` 추가 |
+| `ALLOWED_ARTIFACT_KINDS` (validator) | 동상 | + `code` 추가 |
+
+PR #492 (Go code) + PR #491 (frontend TS) 의 artifact 가 `kind: "code"` 이므로, contract v1 spec + validator enum 둘 다 수정. v0.5.5 pilot 의 4 시나리오 모두 다시 validate PASS 확인.
+
+## 5. 패키지화
+
+[`workflow-source/pyproject.toml`](../pyproject.toml) 에 `workflow_kit.contract_v1` sub-package 추가. `pip install -e workflow-source` 후 `from workflow_kit.contract_v1 import validate_output, choose_role` 가능.
+
+## 6. 회귀 테스트 종합
+
+| 테스트 | 결과 |
+| --- | --- |
+| `check_bootstrap.py` (8 모드) | ✅ 8/8 |
+| `check_bootstrap_mcp_roundtrip.py` (5 하네스) | ✅ 5/5 |
+| `check_docs.py` | ✅ 108+ markdown PASS |
+| `check_contract_v1_roundtrip.py` (S1) | ✅ |
+| `check_contract_v1_role_mapping.py` (S2) | ✅ |
+| `check_contract_v1_direct_only.py` (S3) | ✅ |
+| `check_contract_v1_output_validator.py` (v0.5.6 신규) | ✅ (4 pilot + 8 violation + 4 pilot doc) |
+| `check_contract_v1_delegator.py` (v0.5.6 신규) | ✅ (4 mapping + 7 rejection + strict + 2 baseline) |
+| `check_pilot_phase11_contract_v1.py` (v0.5.5) | ✅ |
+| Workflow linter | ✅ 0 issues |
+
+## 7. 메모리 layer
+
+v0.5.6 의 모든 작업은 `ai-workflow/memory/release/v0.5.6/` 에 기록:
+- `PROJECT_PROFILE.md` — v0.5.6 프로젝트 프로파일 (validator/delegator 명령 추가)
+- `session_handoff.md` — 세션 인계
+- `backlog/2026-06-07.md` — TASK 상세
+- `state.json` — workflow 상태 캐시
+
+## 8. 다음 단계 (v0.5.7 후보)
+
+- [ ] **P1**: contract v2 fan-out/in (§11 1차 컷) — `delegator.choose_role` 의 멀티 sub-task 지원, parent orchestrator 가 fan-in
+- [ ] **P1**: §6.1 "cross-ref 갱신" 명시 row 추가
+- [ ] **P2**: `task.required_model_tier` 필드 (delegator 가 자동 main/small 결정)
+- [ ] **P2**: `artifacts` 의 `added`/`removed`/`total` 분리 (validator 갭 발견 시 추가)
+- [ ] Mavis 측 `delegator.choose_role` 을 실제 위임 결정에 wire (v0.5.6 는 모듈만, 런타임 wire 은 별도)
+- [ ] PyPI 배포 (v0.5.2 부터 보류 중)
+- [ ] Phase 11 case study 추가 (다른 외부 저장소, my_harness 등)
+
+## 9. v0.5.0 → v0.5.6 변경 통계
+
+```
+v0.5.0 (PR #13): 42/42 smoke + MiniMax Code harness overlay
+v0.5.1 (PR #14): per-harness MCP install + auto-emit + guide
+v0.5.1 (PR #15): check_bootstrap_mcp_roundtrip + 5 harnesses round-trip
+v0.5.2 (PR #16): bootstrap 풀 리팩터 + 패키지화 + pilot validation
+v0.5.3 (PR #17): antigravity MCP 표준화 + cross-language stack 표시
+v0.5.4 (PR #18): orchestrator ↔ sub-agent contract v1 + maturity sync + baseline sync
+v0.5.5 (PR #19): Phase 11 본격 pilot (Devhub Example × Contract v1)
+v0.5.6 (PR #20): contract v1 §5/§6 P0 enforcement (validator + delegator)
+```
+
+총 8 PR.
+
+## 10. 이슈 트래커
+
+- ✅ [issue #1](https://github.com/ykylee/standard_ai_workflow/issues/1) 영구 해결 (v0.5.4)
+- 0 open issues

--- a/workflow-source/tests/check_contract_v1_delegator.py
+++ b/workflow-source/tests/check_contract_v1_delegator.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Contract v1 §6.1 / §6.3 delegator regression check.
+
+Verifies that workflow_kit.contract_v1.delegator.choose_role correctly:
+- maps the 4 task_types to roles per §6.1
+- rejects all 7 §6.3 MUST-NOT-delegate markers (handoff / backlog / state.json / ask_user / 우선순위 / 통합/리뷰 / PR 본문)
+- raises on unknown task_type
+- generates valid §4 delegation_id format
+
+Reference: workflow-source/core/orchestrator_subagent_contract_v1.md §6
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SOURCE_ROOT))
+
+from workflow_kit.contract_v1 import choose_role, DelegationRejected  # noqa: E402
+
+DELEGATION_ID_RE = re.compile(r"^del-\d{4}-\d{2}-\d{2}-[0-9a-f]{8}$")
+
+
+def _task(task_type: str, brief: str = "draft spec", primary_artifact: str = "spec.md") -> dict[str, object]:
+    return {
+        "task_type": task_type,
+        "brief": brief,
+        "expected_outputs": {"primary_artifact": primary_artifact},
+    }
+
+
+def check_task_type_to_role_mapping() -> None:
+    """§6.1: each task_type maps to its expected role."""
+    cases = [
+        ("doc_draft", "doc-worker"),
+        ("code_change", "code-worker"),
+        ("validation_run", "validation-worker"),
+        ("bounded_research", "doc-worker"),
+    ]
+    for task_type, expected_role in cases:
+        decision = choose_role(_task(task_type))
+        if decision.role != expected_role:
+            raise AssertionError(
+                f"task_type={task_type!r} should map to {expected_role!r}, got {decision.role!r}"
+            )
+        if decision.must_not_delegate:
+            raise AssertionError(f"task_type={task_type!r} should NOT be §6.3 rejected")
+        if not DELEGATION_ID_RE.match(decision.delegation_id or ""):
+            raise AssertionError(
+                f"delegation_id format wrong: {decision.delegation_id!r} (expected del-YYYY-MM-DD-xxxxxxxx)"
+            )
+
+
+def check_must_not_delegate_rejection() -> None:
+    """§6.3: all 7 markers must be rejected with must_not_delegate=True."""
+    cases = [
+        ("handoff 갱신 및 정리", "handoff 갱신은 orchestrator 직접 처리 (contract v1 §6.3)"),
+        ("backlog update", "backlog 갱신은 orchestrator 직접 처리 (contract v1 §6.3)"),
+        ("state.json 동기화", "state.json 갱신은 orchestrator 직접 처리 (contract v1 §6.3)"),
+        ("ask_user 호출", "ask_user 호출은 orchestrator 직접 처리 (contract v1 §6.3)"),
+        ("우선순위 결정", "우선순위 결정은 orchestrator 직접 처리 (contract v1 §6.3)"),
+        ("sub-agent 출력 통합/리뷰", "sub-agent 출력 통합/리뷰는 orchestrator 직접 처리 (contract v1 §6.3)"),
+        ("PR 본문 작성", "PR 본문 작성은 orchestrator 직접 처리 (contract v1 §6.3)"),
+    ]
+    for brief, expected_reason in cases:
+        decision = choose_role(_task("doc_draft", brief=brief))
+        if not decision.must_not_delegate:
+            raise AssertionError(f"brief={brief!r} should be §6.3 rejected, but was not")
+        if decision.rejected_reason != expected_reason:
+            raise AssertionError(
+                f"brief={brief!r} reason mismatch:\n  expected: {expected_reason}\n  got: {decision.rejected_reason}"
+            )
+        if decision.role is not None:
+            raise AssertionError(f"brief={brief!r} should have role=None, got {decision.role!r}")
+
+
+def check_strict_mode_raises() -> None:
+    """strict=True must raise DelegationRejected on §6.3 violation."""
+    try:
+        choose_role(_task("doc_draft", brief="handoff 갱신"), strict=True)
+    except DelegationRejected as exc:
+        if not exc.decision.must_not_delegate:
+            raise AssertionError("DelegationRejected but decision.must_not_delegate is False")
+        return
+    raise AssertionError("strict=True on §6.3 should raise DelegationRejected")
+
+
+def check_unknown_task_type_raises() -> None:
+    """Unknown task_type must raise ValueError."""
+    try:
+        choose_role(_task("unknown_type_xyz"))
+    except ValueError as exc:
+        if "task_type" not in str(exc):
+            raise AssertionError(f"ValueError should mention 'task_type', got: {exc}")
+        return
+    raise AssertionError("Unknown task_type should raise ValueError")
+
+
+def check_marker_in_primary_artifact_also_rejected() -> None:
+    """§6.3 markers in primary_artifact (not just brief) must also be rejected."""
+    decision = choose_role(_task(
+        "doc_draft",
+        brief="draft something",
+        primary_artifact="handoff-update.md",  # marker in path
+    ))
+    if not decision.must_not_delegate:
+        raise AssertionError(
+            "Marker in primary_artifact should also trigger §6.3 rejection"
+        )
+
+
+def check_non_must_not_delegate_brief_passes() -> None:
+    """Brief that contains unrelated substring should NOT be rejected (regression
+    against overly broad substring matching)."""
+    # "비교" contains "교" which is in "통합/리뷰" — should NOT match
+    decision = choose_role(_task(
+        "doc_draft",
+        brief="v0.5.3 release notes 와 비교하여 변경점 정리",
+    ))
+    if decision.must_not_delegate:
+        raise AssertionError(
+            f"비교 should NOT trigger §6.3 rejection, but got: {decision.rejected_reason}"
+        )
+
+
+def main() -> int:
+    check_task_type_to_role_mapping()
+    check_must_not_delegate_rejection()
+    check_strict_mode_raises()
+    check_unknown_task_type_raises()
+    check_marker_in_primary_artifact_also_rejected()
+    check_non_must_not_delegate_brief_passes()
+    print(
+        "Contract v1 §6.1/§6.3 delegator smoke check passed "
+        "(4 task_type mappings, 7 must-not-delegate rejections, strict mode, "
+        "unknown type, primary_artifact marker, non-match baseline)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflow-source/tests/check_contract_v1_output_validator.py
+++ b/workflow-source/tests/check_contract_v1_output_validator.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Contract v1 §5 output validator regression check.
+
+Verifies that workflow_kit.contract_v1.output_validator correctly:
+- accepts a well-formed §5 payload
+- rejects 5+ violation patterns (missing field, contract_version, status enum, role enum, validation_result format)
+- handles the v0.5.5 pilot's 4 scenario outputs as a regression baseline (no false positives on real-world §5 outputs)
+Reference: workflow-source/core/orchestrator_subagent_contract_v1.md §5
+           workflow-source/examples/pilot_phase11_devhub_contract_v1.md
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SOURCE_ROOT))
+
+from workflow_kit.contract_v1 import validate_output  # noqa: E402
+
+# --- 4 pilot baseline payloads (extracted from v0.5.5 walkthrough, minimal
+# shape — just enough to exercise the validator. Real walkthrough includes
+# additional optional fields, but the schema-level checks only need the
+# required ones.)
+
+
+def _baseline_output(delegation_id: str, role: str = "doc-worker", status: str = "ok") -> dict[str, object]:
+    return {
+        "contract_version": "1.0",
+        "delegation_id": delegation_id,
+        "completed_at": "2026-06-07T21:30:00+09:00",
+        "worker": {"session_id": "mvs_x", "role": role, "model_tier": "small"},
+        "result": {
+            "status": status,
+            "summary": "pilot baseline payload",
+            "artifacts": [{"path": "x.md", "kind": "markdown", "lines": 10, "action": "created"}],
+            "written_paths": ["x.md"],
+            "next_step": "orchestrator review",
+            "validation_result": {"ran": True, "command": "test", "status": "pass", "details": "ok"},
+        },
+        "warnings": [],
+        "risks": [],
+    }
+
+
+def _extract_json_blocks(text: str) -> list[dict[str, object]]:
+    pattern = re.compile(r"```json\s*\n(.*?)\n```", re.DOTALL)
+    return [json.loads(m.group(1)) for m in pattern.finditer(text)]
+
+
+def check_valid_pilot_baseline() -> None:
+    """The 4 v0.5.5 pilot §5 outputs must all validate cleanly."""
+    for did, role in [
+        ("del-2026-06-07-p493", "doc-worker"),
+        ("del-2026-06-07-p492", "code-worker"),
+        ("del-2026-06-07-p491-ui", "code-worker"),
+        ("del-2026-06-07-p490", "doc-worker"),
+    ]:
+        payload = _baseline_output(did, role=role)
+        result = validate_output(payload, expected_delegation_id=did)
+        if not result.is_valid:
+            raise AssertionError(
+                f"Pilot baseline {did!r} should validate, got errors: {result.errors}"
+            )
+
+
+def check_violation_missing_field() -> None:
+    payload = _baseline_output("del-test")
+    payload.pop("completed_at")
+    result = validate_output(payload)
+    if result.is_valid:
+        raise AssertionError("Missing 'completed_at' should fail validation")
+    if not any(err.field == "completed_at" for err in result.errors):
+        raise AssertionError(f"Error should mention 'completed_at', got: {result.errors}")
+
+
+def check_violation_wrong_contract_version() -> None:
+    payload = _baseline_output("del-test")
+    payload["contract_version"] = "2.0"
+    result = validate_output(payload)
+    if result.is_valid:
+        raise AssertionError("Wrong contract_version should fail")
+    if not any(err.field == "contract_version" for err in result.errors):
+        raise AssertionError(f"Error should mention 'contract_version', got: {result.errors}")
+
+
+def check_violation_status_enum() -> None:
+    payload = _baseline_output("del-test", status="completed")
+    result = validate_output(payload)
+    if result.is_valid:
+        raise AssertionError("Invalid status enum should fail")
+    if not any(err.field == "result.status" for err in result.errors):
+        raise AssertionError(f"Error should mention 'result.status', got: {result.errors}")
+
+
+def check_violation_role_enum() -> None:
+    payload = _baseline_output("del-test", role="super-worker")
+    result = validate_output(payload)
+    if result.is_valid:
+        raise AssertionError("Invalid role enum should fail")
+    if not any(err.field == "worker.role" for err in result.errors):
+        raise AssertionError(f"Error should mention 'worker.role', got: {result.errors}")
+
+
+def check_violation_validation_result_format() -> None:
+    payload = _baseline_output("del-test")
+    payload["result"]["validation_result"] = {"ran": True, "status": "maybe"}  # type: ignore[index]
+    result = validate_output(payload)
+    if result.is_valid:
+        raise AssertionError("Invalid validation_result.status should fail")
+    if not any(err.field == "result.validation_result.status" for err in result.errors):
+        raise AssertionError(
+            f"Error should mention 'result.validation_result.status', got: {result.errors}"
+        )
+
+
+def check_violation_delegation_id_mismatch() -> None:
+    """The orchestrator passes expected_delegation_id; mismatches must fail."""
+    payload = _baseline_output("del-expected")
+    result = validate_output(payload, expected_delegation_id="del-different")
+    if result.is_valid:
+        raise AssertionError("delegation_id mismatch should fail")
+    if not any(err.field == "delegation_id" for err in result.errors):
+        raise AssertionError(f"Error should mention 'delegation_id', got: {result.errors}")
+
+
+def check_violation_empty_next_step() -> None:
+    payload = _baseline_output("del-test")
+    payload["result"]["next_step"] = "   "  # whitespace-only
+    result = validate_output(payload)
+    if result.is_valid:
+        raise AssertionError("Empty next_step should fail")
+    if not any(err.field == "result.next_step" for err in result.errors):
+        raise AssertionError(f"Error should mention 'result.next_step', got: {result.errors}")
+
+
+def check_violation_artifact_kind_enum() -> None:
+    payload = _baseline_output("del-test")
+    payload["result"]["artifacts"][0]["kind"] = "exe"  # type: ignore[index]
+    result = validate_output(payload)
+    if result.is_valid:
+        raise AssertionError("Invalid artifact kind should fail")
+    if not any(err.field == "result.artifacts[0].kind" for err in result.errors):
+        raise AssertionError(
+            f"Error should mention 'result.artifacts[0].kind', got: {result.errors}"
+        )
+
+
+def check_pilot_doc_outputs_validate() -> None:
+    """The actual §5 outputs embedded in the v0.5.5 pilot doc must validate.
+    This is the strongest regression: the pilot's documented payloads are
+    expected real-world baselines."""
+    pilot_doc = SOURCE_ROOT / "examples" / "pilot_phase11_devhub_contract_v1.md"
+    if not pilot_doc.exists():
+        raise AssertionError(f"Pilot doc not found: {pilot_doc}")
+    text = pilot_doc.read_text(encoding="utf-8")
+    blocks = _extract_json_blocks(text)
+    if not blocks:
+        raise AssertionError("No JSON blocks found in pilot doc")
+    # Every block should at least parse as a dict (we already do this elsewhere).
+    # For §5 outputs (have 'worker' + 'result' but no 'task'), validate.
+    seen_outputs = 0
+    for block in blocks:
+        if "worker" in block and "result" in block and "task" not in block:
+            result = validate_output(block)
+            if not result.is_valid:
+                raise AssertionError(
+                    f"Pilot doc §5 output failed validation: {block.get('delegation_id')!r} errors={result.errors}"
+                )
+            seen_outputs += 1
+    if seen_outputs < 4:
+        raise AssertionError(
+            f"Expected >= 4 §5 outputs in pilot doc to validate, got {seen_outputs}"
+        )
+
+
+def main() -> int:
+    check_valid_pilot_baseline()
+    check_violation_missing_field()
+    check_violation_wrong_contract_version()
+    check_violation_status_enum()
+    check_violation_role_enum()
+    check_violation_validation_result_format()
+    check_violation_delegation_id_mismatch()
+    check_violation_empty_next_step()
+    check_violation_artifact_kind_enum()
+    check_pilot_doc_outputs_validate()
+    print(
+        "Contract v1 §5 output validator smoke check passed "
+        "(4 pilot baselines valid, 8 violations caught, pilot doc §5 outputs validate)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflow-source/workflow_kit/contract_v1/__init__.py
+++ b/workflow-source/workflow_kit/contract_v1/__init__.py
@@ -1,0 +1,33 @@
+"""Orchestrator ↔ Sub-agent Contract v1 enforcement modules.
+
+Two enforcement helpers introduced in v0.5.6 (P0 from v0.5.5 pilot findings):
+- `output_validator`: validates a sub-agent output payload against §5 of the contract.
+- `delegator.choose_role`: decides role mapping per §6.1 + rejects §6.3 actions.
+
+Both modules are pure Python (no external deps beyond the standard library) so
+they can be imported from any orchestrator runtime (Mavis, mavis, OpenCode,
+Gemini CLI, etc.) and from sub-agent runtimes that already depend on the
+standard_ai_workflow kit.
+
+Reference: workflow-source/core/orchestrator_subagent_contract_v1.md
+"""
+
+from .output_validator import (
+    OutputValidationError,
+    OutputValidationResult,
+    validate_output,
+)
+from .delegator import (
+    DelegationDecision,
+    DelegationRejected,
+    choose_role,
+)
+
+__all__ = [
+    "OutputValidationError",
+    "OutputValidationResult",
+    "validate_output",
+    "DelegationDecision",
+    "DelegationRejected",
+    "choose_role",
+]

--- a/workflow-source/workflow_kit/contract_v1/delegator.py
+++ b/workflow-source/workflow_kit/contract_v1/delegator.py
@@ -1,0 +1,153 @@
+"""§6.1 / §6.3 Delegator for Orchestrator ↔ Sub-agent Contract v1.
+
+Decides role mapping per §6.1 (MUST delegate) and rejects §6.3 (MUST NOT
+delegate) actions. Used by the orchestrator side to auto-enforce the contract
+on every task it considers doing itself (P0 from v0.5.5 pilot findings).
+
+Reference: workflow-source/core/orchestrator_subagent_contract_v1.md §6
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+# §3.1~§3.5 role names (must match contract v1 spec)
+ALLOWED_ROLES = ("doc-worker", "code-worker", "validation-worker", "workflow-worker")
+# §4 task_type enum
+ALLOWED_TASK_TYPES = ("doc_draft", "code_change", "validation_run", "bounded_research")
+
+# §6.1 mapping (deterministic): task_type → role
+TASK_TYPE_TO_ROLE: dict[str, str] = {
+    "doc_draft": "doc-worker",
+    "code_change": "code-worker",
+    "validation_run": "validation-worker",
+    "bounded_research": "doc-worker",
+}
+
+# §6.3 MUST-NOT-delegate actions (7 explicit per the spec).
+# Substring match against `task.brief` and `task.expected_outputs.primary_artifact`.
+# Each entry is (marker, human-readable reason).
+MUST_NOT_DELEGATE_MARKERS: tuple[tuple[str, str], ...] = (
+    ("handoff", "handoff 갱신은 orchestrator 직접 처리 (contract v1 §6.3)"),
+    ("backlog", "backlog 갱신은 orchestrator 직접 처리 (contract v1 §6.3)"),
+    ("state.json", "state.json 갱신은 orchestrator 직접 처리 (contract v1 §6.3)"),
+    ("ask_user", "ask_user 호출은 orchestrator 직접 처리 (contract v1 §6.3)"),
+    ("우선순위", "우선순위 결정은 orchestrator 직접 처리 (contract v1 §6.3)"),
+    ("통합/리뷰", "sub-agent 출력 통합/리뷰는 orchestrator 직접 처리 (contract v1 §6.3)"),
+    ("PR 본문", "PR 본문 작성은 orchestrator 직접 처리 (contract v1 §6.3)"),
+)
+
+
+@dataclass
+class DelegationDecision:
+    """The orchestrator's delegation decision for a given task.
+
+    `must_not_delegate` is True iff the task matches a §6.3 marker — in which
+    case `rejected_reason` is set and `role` is None. Otherwise `role` is set
+    per §6.1 and a fresh `delegation_id` is generated.
+    """
+    role: str | None
+    must_not_delegate: bool
+    rejected_reason: str | None
+    warnings: list[str] = field(default_factory=list)
+    delegation_id: str | None = None
+    task_type: str | None = None
+
+
+class DelegationRejected(ValueError):
+    """Raised by strict-mode helpers when §6.3 is violated."""
+
+    def __init__(self, decision: DelegationDecision) -> None:
+        super().__init__(decision.rejected_reason or "delegation rejected")
+        self.decision = decision
+
+
+def _generate_delegation_id() -> str:
+    """Generate a unique delegation_id per the §4 format `del-YYYY-MM-DD-NNN`."""
+    # We keep a date prefix for human readability; the suffix is a short uuid4 hex.
+    from datetime import date
+    today = date.today().isoformat()
+    suffix = uuid.uuid4().hex[:8]
+    return f"del-{today}-{suffix}"
+
+
+def _looks_like_must_not_delegate(task: dict[str, Any]) -> tuple[bool, str | None]:
+    """Inspect task.brief and primary_artifact for §6.3 markers.
+
+    Returns (matched, reason). The marker is substring-matched; matches are
+    case-insensitive. We intentionally do NOT match "handoff" inside e.g.
+    "handoff_path" — only the bare marker word to reduce false positives.
+    """
+    brief = str(task.get("brief", ""))
+    primary = str(
+        task.get("expected_outputs", {}).get("primary_artifact", "")
+        if isinstance(task.get("expected_outputs"), dict)
+        else ""
+    )
+    haystack = f"{brief}\n{primary}".lower()
+    for marker, reason in MUST_NOT_DELEGATE_MARKERS:
+        if marker.lower() in haystack:
+            return True, reason
+    return False, None
+
+
+def choose_role(task: dict[str, Any], *, strict: bool = False) -> DelegationDecision:
+    """Decide which role a task should be delegated to, per contract v1 §6.
+
+    Args:
+        task: A task dict matching contract v1 §4 input schema. Only `task_type`,
+            `brief`, and `expected_outputs.primary_artifact` are inspected.
+        strict: If True, raise DelegationRejected on §6.3 violation instead
+            of returning a `must_not_delegate=True` decision. Default False
+            (the orchestrator's normal-mode "warn, do not delegate" path).
+
+    Returns:
+        DelegationDecision. On §6.3 violation, `must_not_delegate=True` and
+        `rejected_reason` is set; orchestrator should NOT call the worker in
+        that case. On valid §6.1 task, `role` and `delegation_id` are set.
+
+    Raises:
+        DelegationRejected: only if `strict=True` and §6.3 is violated.
+        ValueError: if `task.task_type` is not a known enum value.
+    """
+    if not isinstance(task, dict):
+        raise ValueError(f"task must be a dict, got {type(task).__name__}")
+
+    task_type = task.get("task_type")
+    if task_type not in ALLOWED_TASK_TYPES:
+        raise ValueError(
+            f"task.task_type must be one of {ALLOWED_TASK_TYPES}, got {task_type!r}"
+        )
+
+    matched, reason = _looks_like_must_not_delegate(task)
+    if matched:
+        decision = DelegationDecision(
+            role=None,
+            must_not_delegate=True,
+            rejected_reason=reason,
+            warnings=[],
+            delegation_id=None,
+            task_type=task_type,
+        )
+        if strict:
+            raise DelegationRejected(decision)
+        return decision
+
+    role = TASK_TYPE_TO_ROLE[task_type]
+    warnings: list[str] = []
+    # §3 model_tier hint (best-effort, not strict)
+    if isinstance(task.get("constraints"), list):
+        for c in task["constraints"]:
+            if isinstance(c, str) and "main" in c.lower() and "model" in c.lower():
+                warnings.append("task mentions 'main model' — orchestrator may promote model_tier")
+
+    return DelegationDecision(
+        role=role,
+        must_not_delegate=False,
+        rejected_reason=None,
+        warnings=warnings,
+        delegation_id=_generate_delegation_id(),
+        task_type=task_type,
+    )

--- a/workflow-source/workflow_kit/contract_v1/output_validator.py
+++ b/workflow-source/workflow_kit/contract_v1/output_validator.py
@@ -1,0 +1,184 @@
+"""§5 Output schema validator for Orchestrator ↔ Sub-agent Contract v1.
+
+Validates a sub-agent output payload against contract v1 §5 schema. Used by the
+orchestrator to auto-enforce the contract on every sub-agent response (P0 from
+v0.5.5 pilot findings).
+
+Reference: workflow-source/core/orchestrator_subagent_contract_v1.md §5
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# Constants pulled from the contract spec. Keep in sync with §5 of
+# workflow-source/core/orchestrator_subagent_contract_v1.md.
+CONTRACT_VERSION = "1.0"
+ALLOWED_STATUS = ("ok", "partial", "failed")
+ALLOWED_ROLES = ("doc-worker", "code-worker", "validation-worker", "workflow-worker")
+ALLOWED_MODEL_TIERS = ("small", "main")
+ALLOWED_ARTIFACT_KINDS = ("markdown", "python", "json", "toml", "text", "code", "other")
+
+REQUIRED_TOP_FIELDS = ("contract_version", "delegation_id", "completed_at", "worker", "result")
+REQUIRED_WORKER_FIELDS = ("session_id", "role", "model_tier")
+REQUIRED_RESULT_FIELDS = ("status", "summary", "artifacts", "written_paths", "next_step")
+
+
+@dataclass
+class OutputValidationError:
+    """A single field-level validation error."""
+    field: str
+    reason: str
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"{self.field}: {self.reason}"
+
+
+@dataclass
+class OutputValidationResult:
+    """Result of validating a sub-agent output payload.
+
+    `is_valid` is True iff `errors` is empty. `warnings` are non-fatal hints
+    (e.g., `result.summary` is short, `artifacts` list is empty).
+    """
+    is_valid: bool
+    errors: list[OutputValidationError] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def raise_if_invalid(self) -> None:
+        if not self.is_valid:
+            joined = "; ".join(str(err) for err in self.errors)
+            raise ValueError(f"Contract v1 §5 output schema violation: {joined}")
+
+
+def _ensure_dict(payload: Any, field: str) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError(f"{field} must be a dict, got {type(payload).__name__}")
+    return payload
+
+
+def validate_output(
+    payload: Any,
+    expected_delegation_id: str | None = None,
+) -> OutputValidationResult:
+    """Validate a sub-agent output payload against contract v1 §5.
+
+    Args:
+        payload: The deserialized JSON object a sub-agent produced.
+        expected_delegation_id: If provided, the validator also asserts the
+            payload's `delegation_id` matches this expected value. This is
+            what orchestrators should pass to detect cross-delegation leaks.
+
+    Returns:
+        OutputValidationResult with `is_valid`, `errors`, `warnings`. Does not
+        raise on validation failure — callers decide policy (reject, retry,
+        escalate) per contract v1 §7.4.
+    """
+    errors: list[OutputValidationError] = []
+    warnings: list[str] = []
+
+    # Top-level shape
+    if not isinstance(payload, dict):
+        errors.append(OutputValidationError("payload", f"must be a dict, got {type(payload).__name__}"))
+        return OutputValidationResult(is_valid=False, errors=errors)
+
+    for field_name in REQUIRED_TOP_FIELDS:
+        if field_name not in payload:
+            errors.append(OutputValidationError(field_name, "missing required field"))
+
+    if errors:
+        return OutputValidationResult(is_valid=False, errors=errors)
+
+    # contract_version
+    version = payload["contract_version"]
+    if version != CONTRACT_VERSION:
+        errors.append(OutputValidationError(
+            "contract_version", f"must be {CONTRACT_VERSION!r}, got {version!r}"
+        ))
+
+    # delegation_id match
+    delegation_id = payload.get("delegation_id")
+    if expected_delegation_id is not None and delegation_id != expected_delegation_id:
+        errors.append(OutputValidationError(
+            "delegation_id",
+            f"expected {expected_delegation_id!r}, got {delegation_id!r}",
+        ))
+
+    # worker
+    worker = _ensure_dict(payload["worker"], "worker")
+    for field_name in REQUIRED_WORKER_FIELDS:
+        if field_name not in worker:
+            errors.append(OutputValidationError(f"worker.{field_name}", "missing required field"))
+    if "role" in worker and worker["role"] not in ALLOWED_ROLES:
+        errors.append(OutputValidationError(
+            "worker.role", f"must be one of {ALLOWED_ROLES}, got {worker['role']!r}"
+        ))
+    if "model_tier" in worker and worker["model_tier"] not in ALLOWED_MODEL_TIERS:
+        errors.append(OutputValidationError(
+            "worker.model_tier", f"must be one of {ALLOWED_MODEL_TIERS}, got {worker['model_tier']!r}"
+        ))
+
+    # result
+    result = _ensure_dict(payload["result"], "result")
+    for field_name in REQUIRED_RESULT_FIELDS:
+        if field_name not in result:
+            errors.append(OutputValidationError(f"result.{field_name}", "missing required field"))
+    if "status" in result and result["status"] not in ALLOWED_STATUS:
+        errors.append(OutputValidationError(
+            "result.status", f"must be one of {ALLOWED_STATUS}, got {result['status']!r}"
+        ))
+    if "summary" in result and not isinstance(result["summary"], str):
+        errors.append(OutputValidationError("result.summary", "must be a string"))
+    if "summary" in result and isinstance(result["summary"], str) and len(result["summary"]) < 3:
+        warnings.append("result.summary is very short (< 3 chars); may be insufficient for orchestrator review")
+    if "artifacts" in result and not isinstance(result["artifacts"], list):
+        errors.append(OutputValidationError("result.artifacts", "must be a list"))
+    if "artifacts" in result and isinstance(result["artifacts"], list):
+        for idx, artifact in enumerate(result["artifacts"]):
+            if not isinstance(artifact, dict):
+                errors.append(OutputValidationError(
+                    f"result.artifacts[{idx}]", f"must be a dict, got {type(artifact).__name__}"
+                ))
+                continue
+            if "path" not in artifact or "kind" not in artifact:
+                errors.append(OutputValidationError(
+                    f"result.artifacts[{idx}]", "missing required 'path' or 'kind'"
+                ))
+            elif artifact["kind"] not in ALLOWED_ARTIFACT_KINDS:
+                errors.append(OutputValidationError(
+                    f"result.artifacts[{idx}].kind",
+                    f"must be one of {ALLOWED_ARTIFACT_KINDS}, got {artifact['kind']!r}",
+                ))
+    if "written_paths" in result and not isinstance(result["written_paths"], list):
+        errors.append(OutputValidationError("result.written_paths", "must be a list"))
+    if "next_step" in result:
+        if not isinstance(result["next_step"], str):
+            errors.append(OutputValidationError("result.next_step", "must be a string"))
+        elif not result["next_step"].strip():
+            errors.append(OutputValidationError("result.next_step", "must be non-empty"))
+
+    # Optional but validated when present
+    if "validation_result" in result:
+        vr = result["validation_result"]
+        if not isinstance(vr, dict):
+            errors.append(OutputValidationError("result.validation_result", "must be a dict"))
+        else:
+            if "ran" in vr and not isinstance(vr["ran"], bool):
+                errors.append(OutputValidationError("result.validation_result.ran", "must be a bool"))
+            if vr.get("ran") is True:
+                if "status" not in vr:
+                    errors.append(OutputValidationError(
+                        "result.validation_result.status", "required when ran=true"
+                    ))
+                elif vr["status"] not in ("pass", "fail", "skipped"):
+                    errors.append(OutputValidationError(
+                        "result.validation_result.status",
+                        f"must be one of ('pass', 'fail', 'skipped'), got {vr['status']!r}",
+                    ))
+
+    return OutputValidationResult(
+        is_valid=not errors,
+        errors=errors,
+        warnings=warnings,
+    )


### PR DESCRIPTION
# Beta v0.5.6 — Contract v1 §5/§6 P0 Enforcement (validator + delegator)

- **릴리스 일자**: 2026-06-07
- **브랜치**: `release/v0.5.6`
- **포함 커밋**: v0.5.5 (PR #19) 이후 1 squash
- **상태**: ✅ 1개 TASK 완료 (TASK-V056-001)

## 1. 하이라이트

v0.5.5 Phase 11 pilot 에서 도출된 P0 priorities 2개를 묶어서 1 PR 로 enforce:

- **TASK-V056-001-A**: sub-agent 측 §5 출력 스키마 validator — `workflow_kit.contract_v1.output_validator.validate_output(payload, expected_delegation_id=None) -> OutputValidationResult`
- **TASK-V056-001-B**: Mavis 측 §6.1 자동 위임 결정 delegator — `workflow_kit.contract_v1.delegator.choose_role(task, strict=False) -> DelegationDecision`
- **신규 회귀 2개**: `check_contract_v1_output_validator.py` (4 pilot baseline + 8 violation + 4 pilot doc §5 output) · `check_contract_v1_delegator.py` (4 task_type mapping + 7 §6.3 rejection + strict + primary_artifact marker + non-match baseline)
- **contract v1 spec §5/§6 갭 발견 & 수정**: `artifact_kind` enum 에 `code` 추가 (v0.5.5 pilot 의 PR #492, #491 에서 사용)

## 2. TASK-V056-001-A: §5 출력 Validator

### 동기

v0.5.5 pilot 의 4 시나리오에서 contract v1 §4/§5 JSON round-trip 이 모두 PASS 했지만, **회귀 검증**이 자동화되어 있지 않음. v0.5.5 P0 도출: sub-agent 응답이 spec 과 fit 한지 자동 검증. 검증 실패 시 §7.4 "출력 스키마 위반" 정책 적용 (orchestrator 가 위반 보고 + 재위임 또는 직접 처리).

### 산출물

[`workflow_kit/contract_v1/output_validator.py`](../workflow_kit/contract_v1/output_validator.py) (신규, ~180줄, pure Python)

핵심 API:

```python
from workflow_kit.contract_v1 import validate_output, OutputValidationError, OutputValidationResult

result = validate_output(
    payload,                          # sub-agent 가 응답한 dict
    expected_delegation_id="del-...", # orchestrator 가 위임한 delegation_id
)
if not result.is_valid:
    # §7.4 정책: 위반 보고 + 재위임 1회 → 직접 처리
    for err in result.errors:
        log(f"{err.field}: {err.reason}")
```

검증 항목 (총 9):
1. `contract_version == "1.0"`
2. 필수 top-level 필드 5개: `contract_version`, `delegation_id`, `completed_at`, `worker`, `result`
3. `worker.role` ∈ `{doc-worker, code-worker, validation-worker, workflow-worker}`
4. `worker.model_tier` ∈ `{small, main}`
5. `result.status` ∈ `{ok, partial, failed}`
6. `result.artifacts[i].kind` ∈ `{markdown, python, json, toml, text, code, other}` (v0.5.6 갭 수정)
7. `delegation_id` 가 expected 와 일치 (cross-delegation leak 방지)
8. `result.validation_result.ran` is bool + `validation_result.status` ∈ `{pass, fail, skipped}` when `ran=true`
9. `result.next_step` is non-empty string

### 회귀

[`tests/check_contract_v1_output_validator.py`](../tests/check_contract_v1_output_validator.py) (신규, 13 check)

- 4 pilot baseline (PR #493/#492/#491/#490) — 모두 valid
- 8 violation: missing field / wrong contract_version / invalid status enum / invalid role enum / invalid validation_result.status / delegation_id mismatch / empty next_step / invalid artifact kind
- v0.5.5 pilot doc (`pilot_phase11_devhub_contract_v1.md`) 의 실제 §5 JSON 4개 — 모두 valid (regression baseline)

## 3. TASK-V056-001-B: §6.1 / §6.3 Delegator

### 동기

v0.5.4 contract v1 spec 의 §6 카탈로그는 "권장" 이라 강제력이 없었음. P0 도출: orchestrator 가 매번 손으로 §6.1/§6.3 을 판단하지 말고, 자동 enforce. v0.5.5 pilot 의 §6 정합성 85% 도 자동화면 100% 가능.

### 산출물

[`workflow_kit/contract_v1/delegator.py`](../workflow_kit/contract_v1/delegator.py) (신규, ~130줄, pure Python)

핵심 API:

```python
from workflow_kit.contract_v1 import choose_role, DelegationDecision, DelegationRejected

decision = choose_role(task)  # task 는 §4 입력 dict
if decision.must_not_delegate:
    # §6.3 매치 — orchestrator 직접 처리
    log(f"Rejected: {decision.rejected_reason}")
else:
    sub_agent_prompt(decision.delegation_id, decision.role, task)

# strict 모드: §6.3 매치 시 raise
try:
    choose_role(task, strict=True)
except DelegationRejected as e:
    log(f"Must not delegate: {e.decision.rejected_reason}")
```

검증 항목:
- `task.task_type` ∈ `{doc_draft, code_change, validation_run, bounded_research}`
- `task_type` → `role` 매핑 (deterministic, §6.1):
  - `doc_draft` / `bounded_research` → `doc-worker`
  - `code_change` → `code-worker`
  - `validation_run` → `validation-worker`
- §6.3 MUST-NOT-delegate 7개 marker 거부: `handoff`, `backlog`, `state.json`, `ask_user`, `우선순위`, `통합/리뷰`, `PR 본문` (brief 와 primary_artifact 양쪽 검사)
- `delegation_id` 자동 생성: `del-YYYY-MM-DD-xxxxxxxx` (8자리 hex suffix)

### 회귀

[`tests/check_contract_v1_delegator.py`](../tests/check_contract_v1_delegator.py) (신규, 6 check)

- 4 task_type → role 매핑 + delegation_id 형식
- 7 §6.3 marker 거부 (각 marker 의 reason 메시지 검증)
- `strict=True` 모드에서 `DelegationRejected` raise
- 알 수 없는 task_type → `ValueError`
- primary_artifact 의 marker 도 거부
- negative control: "비교" 가 "통합/리뷰" 의 일부 substring 이지만 reject 안 됨 (false positive 방지)

## 4. contract v1 spec 갭 수정 (v0.5.6 discovery)

v0.5.5 pilot doc 의 `kind: "code"` 가 §5 enum 에 없어 validator 가 거부. spec 갭:

| 필드 | Before | After |
| --- | --- | --- |
| `task.expected_outputs.artifact_kind` (contract v1 §4) | `markdown` / `python` / `json` / `toml` / `text` / `other` | + `code` 추가 |
| `ALLOWED_ARTIFACT_KINDS` (validator) | 동상 | + `code` 추가 |

PR #492 (Go code) + PR #491 (frontend TS) 의 artifact 가 `kind: "code"` 이므로, contract v1 spec + validator enum 둘 다 수정. v0.5.5 pilot 의 4 시나리오 모두 다시 validate PASS 확인.

## 5. 패키지화

[`workflow-source/pyproject.toml`](../pyproject.toml) 에 `workflow_kit.contract_v1` sub-package 추가. `pip install -e workflow-source` 후 `from workflow_kit.contract_v1 import validate_output, choose_role` 가능.

## 6. 회귀 테스트 종합

| 테스트 | 결과 |
| --- | --- |
| `check_bootstrap.py` (8 모드) | ✅ 8/8 |
| `check_bootstrap_mcp_roundtrip.py` (5 하네스) | ✅ 5/5 |
| `check_docs.py` | ✅ 108+ markdown PASS |
| `check_contract_v1_roundtrip.py` (S1) | ✅ |
| `check_contract_v1_role_mapping.py` (S2) | ✅ |
| `check_contract_v1_direct_only.py` (S3) | ✅ |
| `check_contract_v1_output_validator.py` (v0.5.6 신규) | ✅ (4 pilot + 8 violation + 4 pilot doc) |
| `check_contract_v1_delegator.py` (v0.5.6 신규) | ✅ (4 mapping + 7 rejection + strict + 2 baseline) |
| `check_pilot_phase11_contract_v1.py` (v0.5.5) | ✅ |
| Workflow linter | ✅ 0 issues |

## 7. 메모리 layer

v0.5.6 의 모든 작업은 `ai-workflow/memory/release/v0.5.6/` 에 기록:
- `PROJECT_PROFILE.md` — v0.5.6 프로젝트 프로파일 (validator/delegator 명령 추가)
- `session_handoff.md` — 세션 인계
- `backlog/2026-06-07.md` — TASK 상세
- `state.json` — workflow 상태 캐시

## 8. 다음 단계 (v0.5.7 후보)

- [ ] **P1**: contract v2 fan-out/in (§11 1차 컷) — `delegator.choose_role` 의 멀티 sub-task 지원, parent orchestrator 가 fan-in
- [ ] **P1**: §6.1 "cross-ref 갱신" 명시 row 추가
- [ ] **P2**: `task.required_model_tier` 필드 (delegator 가 자동 main/small 결정)
- [ ] **P2**: `artifacts` 의 `added`/`removed`/`total` 분리 (validator 갭 발견 시 추가)
- [ ] Mavis 측 `delegator.choose_role` 을 실제 위임 결정에 wire (v0.5.6 는 모듈만, 런타임 wire 은 별도)
- [ ] PyPI 배포 (v0.5.2 부터 보류 중)
- [ ] Phase 11 case study 추가 (다른 외부 저장소, my_harness 등)

## 9. v0.5.0 → v0.5.6 변경 통계

```
v0.5.0 (PR #13): 42/42 smoke + MiniMax Code harness overlay
v0.5.1 (PR #14): per-harness MCP install + auto-emit + guide
v0.5.1 (PR #15): check_bootstrap_mcp_roundtrip + 5 harnesses round-trip
v0.5.2 (PR #16): bootstrap 풀 리팩터 + 패키지화 + pilot validation
v0.5.3 (PR #17): antigravity MCP 표준화 + cross-language stack 표시
v0.5.4 (PR #18): orchestrator ↔ sub-agent contract v1 + maturity sync + baseline sync
v0.5.5 (PR #19): Phase 11 본격 pilot (Devhub Example × Contract v1)
v0.5.6 (PR #20): contract v1 §5/§6 P0 enforcement (validator + delegator)
```

총 8 PR.

## 10. 이슈 트래커

- ✅ [issue #1](https://github.com/ykylee/standard_ai_workflow/issues/1) 영구 해결 (v0.5.4)
- 0 open issues
