### PR TITLE
feat(v0.5.7): contract v1 §4.2/§5.2 multi-component fan-out/in + §6.3 cross-ref row

### DIFF
--- a/ai-workflow/memory/release/v0.5.7/PROJECT_PROFILE.md
+++ b/ai-workflow/memory/release/v0.5.7/PROJECT_PROFILE.md
@@ -1,0 +1,64 @@
+# Project Workflow Profile
+
+- 문서 목적: Standard AI Workflow 저장소 자체의 운영 규칙과 검증 기준을 정의한다.
+- 범위: 저장소 개요, 문서 구조, 기본 명령, 검증 포인트, 예외 규칙
+- 대상 독자: 저장소 maintainer (`ykylee`), 워크플로우 도입 검토자, 멀티 에이전트 운영자
+- 상태: stable
+- 최종 수정일: 2026-06-08
+- 관련 문서: [공통 표준](../../../../workflow-source/core/global_workflow_standard.md), [Maturity Matrix](../../../../workflow-source/core/maturity_matrix.json), [Orchestrator ↔ Sub-agent Contract v1](../../../../workflow-source/core/orchestrator_subagent_contract_v1.md), [Wire 가이드](../../../../workflow-source/core/orchestrator_contract_v1_wire_guide.md)
+
+## 1. 프로젝트 개요
+
+- 프로젝트명: **Standard AI Workflow**
+- 프로젝트 슬러그: `standard-ai-workflow`
+- 프로젝트 목적: 여러 프로젝트에서 공통으로 사용할 수 있는 표준 AI 협업 워크플로우 문서와 템플릿, skill/MCP/agent 구현 기준을 독립 프로젝트 형태로 제공한다.
+- 주요 이해관계자: 저장소 maintainer (`ykylee`), 워크플로우 도입 검토자, 멀티 에이전트 운영자
+- 현재 베이스라인: **v0.5.7-beta** (in progress; v0.5.6 위에 P1 fan-out/in + P2 model_tier 자동 + §6.3 cross-ref row)
+
+## 2. 문서 구조 (Path)
+
+- 문서 위키 홈: [`docs/README.md`](../../../../docs/README.md)
+- 운영 문서 홈: `ai-workflow/memory/`
+- 백로그 위치: `ai-workflow/memory/backlog/`
+- 세션 인계 문서: `ai-workflow/memory/session_handoff.md`
+- 환경 기록 위치: `ai-workflow/memory/environments/`
+
+## 3. 운영 / 검증 명령
+
+- **venv 셋업 (최초 1회)**: `python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt -r requirements-dev.txt`
+- bootstrap dry-run: `python3 workflow-source/scripts/bootstrap_workflow_kit.py --target-root . --project-slug demo --project-name "Demo" --harness codex --dry-run`
+- bootstrap 실제 실행: `python3 workflow-source/scripts/bootstrap_workflow_kit.py --target-root . --project-slug demo --project-name "Demo" --harness codex --copy-core-docs`
+- 회귀: `python workflow-source/tests/check_bootstrap.py`
+- 회귀 (MCP): `python workflow-source/tests/check_bootstrap_mcp_roundtrip.py`
+- 문서 링크 검증: `python workflow-source/tests/check_docs.py`
+- contract v1:
+  - `python workflow-source/tests/check_contract_v1_roundtrip.py`
+  - `python workflow-source/tests/check_contract_v1_role_mapping.py`
+  - `python workflow-source/tests/check_contract_v1_direct_only.py`
+  - `python workflow-source/tests/check_contract_v1_output_validator.py` (v0.5.6)
+  - `python workflow-source/tests/check_contract_v1_delegator.py` (v0.5.6 + v0.5.7 model_tier 확장)
+  - `python workflow-source/tests/check_contract_v1_multi_component.py` (v0.5.7 신규)
+- pilot phase11 (v0.5.5): `python workflow-source/tests/check_pilot_phase11_contract_v1.py`
+- 워크플로우 linter: `PYTHONPATH=workflow-source python workflow-source/skills/workflow-linter/scripts/run_workflow_linter.py --project-profile-path docs/PROJECT_PROFILE.md --state-json-path ai-workflow/memory/release/v0.5.7/state.json --session-handoff-path ai-workflow/memory/release/v0.5.7/session_handoff.md --latest-backlog-path ai-workflow/memory/release/v0.5.7/backlog/2026-06-08.md`
+
+## 4. 예외 규칙
+
+- 새 하네스 overlay 추가 시 `bootstrap_lib/harnesses/` 아래에 renderer + `HARNESS_SPECS` 등록 + `__main__.py` 의 `register_harness_builder` 호출이 모두 세트로 들어가야 한다.
+- `bootstrap_workflow_kit.py` 는 thin re-export entry. 직접 import 하지 말고 `bootstrap_lib.*` 사용.
+- `--enable-mcp` 의 MCP config 출력 경로는 하네스별 dot-dir 컨벤션(`.codex/`, `.gemini/`, `.MiniMax/`, `.antigravity/`)을 따른다.
+- `requirements.txt` / `package.json` 자동 갱신은 `--update-deps` 옵션일 때만.
+- 승인: `core/` 문서 (특히 `global_workflow_standard.md`, `maturity_matrix.json`, `orchestrator_subagent_contract_v1.md`, `orchestrator_contract_v1_wire_guide.md`) 변경 시 자체 self-review 필수
+- (v0.5.4 부터) orchestrator는 sub-agent 위임 가능한 작업을 직접 도구 호출로 처리하지 않는다 (제6.1장). 자세한 contract: `../workflow-source/core/orchestrator_subagent_contract_v1.md`.
+- (v0.5.6) sub-agent 출력은 `workflow_kit.contract_v1.output_validator.validate_output()` 으로 자동 검증 후 orchestrator 에 보고. 검증 실패 시 §7.4 의 "출력 스키마 위반" 정책 적용.
+- (v0.5.7) 멀티 컴포넌트 sub-task 는 `delegator.choose_roles()` (fan-out) + `output_validator.validate_fanin_output()` (fan-in) 으로 자동 enforce. cross-ref 갱신 / fan-in 통합 보고 / parent_delegation_id 발급은 §6.3 에 따라 orchestrator 직접 처리. 자세한 wire 패턴: `../workflow-source/core/orchestrator_contract_v1_wire_guide.md`.
+- (v0.5.7) `task.required_model_tier` 가 명시되지 않으면 `delegator.recommend_model_tier()` 가 main keyword (아키텍처/정책/5+ 파일/cross-cutting/5+ source) 기반 자동 결정. `choose_role` 결과의 `decision.recommended_model_tier` 에 박힘.
+
+## 5. 다음에 읽을 문서
+
+- [Maturity Matrix](../../../../workflow-source/core/maturity_matrix.json)
+- [Orchestrator ↔ Sub-agent Contract v1](../../../../workflow-source/core/orchestrator_subagent_contract_v1.md)
+- [Wire 가이드](../../../../workflow-source/core/orchestrator_contract_v1_wire_guide.md) (v0.5.7 신규)
+- [세션 인계 문서](./session_handoff.md)
+- [작업 백로그 인덱스](../../work_backlog.md)
+- [Pilot result v0.5.5](../../../../workflow-source/examples/pilot_phase11_devhub_contract_v1.md)
+- [릴리스 노트 v0.5.7](../../../../workflow-source/releases/Beta-v0.5.7.md)

--- a/ai-workflow/memory/release/v0.5.7/backlog/2026-06-08.md
+++ b/ai-workflow/memory/release/v0.5.7/backlog/2026-06-08.md
@@ -1,0 +1,88 @@
+# Backlog — 2026-06-08 (v0.5.7)
+
+- 문서 목적: v0.5.7 릴리스의 작업 백로그 — TASK-V057-001 (multi-component fan-out/in + cross-ref row) 의 동기, sub-task, 산출물, 회귀
+- 범위: 2026-06-08 한정 작업 기록. v0.5.7 PR #21 의 squash 본문에 들어갈 상세
+- 대상 독자: 다음 세션 오케스트레이터, v0.5.7 회귀 추적자, v0.5.8 후속 작업자
+- 상태: closed (v0.5.7 ship 직전, 모든 sub-task done)
+- 최종 수정일: 2026-06-08
+- 관련 문서: `workflow-source/releases/Beta-v0.5.7.md`, [PROJECT_PROFILE v0.5.7](../PROJECT_PROFILE.md), [session_handoff v0.5.7](../session_handoff.md), `workflow-source/core/orchestrator_subagent_contract_v1.md`, `workflow-source/core/orchestrator_contract_v1_wire_guide.md`
+
+---
+
+## TASK-V057-001: Contract v1 §4.2/§5.2 multi-component fan-out/in + §6.3 cross-ref row
+
+**상태**: ✅ done
+**브랜치**: `release/v0.5.7`
+**스펠 백로그**: [GitHub issue #1](https://github.com/ykylee/standard_ai_workflow/issues/1) (영구 해결됨 v0.5.4 부터)
+
+### 동기
+
+v0.5.5 pilot 의 4 시나리오는 모두 single-task 위임. v0.5.5 P1 도출:
+1. contract v2 fan-out/in — v0.5.7 에서 1차 컷
+2. §6.1 "cross-ref 갱신" 명시 row 추가
+
+v0.5.5 P2 도출:
+- `task.required_model_tier` 자동 결정
+- `artifacts` 의 `added`/`removed`/`total` 분리
+
+### sub-task
+
+#### A. §4.2/§5.2 fan-out/in 구현
+- `delegator.choose_roles(task, strict=False) -> list[DelegationDecision]`
+  - `task.sub_tasks` 가 있으면 fan-out, 없으면 단일 결과 (`[choose_role(task)]`)
+  - 각 sub-task 별 `choose_role` 호출, `sub_id` + parent-prefix delegation_id
+  - §6.3 매치 (parent or sub) 시 전체 reject
+- `output_validator.validate_fanin_output(payload, expected_parent_delegation_id=None) -> OutputValidationResult`
+  - sub_results 필수 5필드
+  - sub_result.delegation_id 가 parent prefix 로 시작
+  - aggregated status 일관성 (any failed→failed, any partial→partial, else ok)
+
+#### B. §6.3 cross-ref / fan-in 통합 row 추가
+- MUST_NOT_DELEGATE_MARKERS 7→9
+- 새 marker: `cross-ref`, `fan-in 통합`
+- 매치 검사: sub_tasks[].brief 까지 haystack 포함
+
+#### C. (P2) required_model_tier 자동 결정
+- `delegator.recommend_model_tier(task) -> "small" | "main"`
+- main 후보 keyword: 아키텍처, 정책, 5+ 파일, cross-cutting, 5+ source
+- 명시 `task.required_model_tier` 있으면 override
+- `choose_role` 결과의 `decision.recommended_model_tier` 에 박힘
+
+#### D. (P2) artifacts action + stats
+- `result.artifacts[i].action` (created/modified/deleted)
+- `result.artifacts[i].added`/`removed`/`total` (int)
+
+#### 추가: Mavis 측 wire 가이드
+- `core/orchestrator_contract_v1_wire_guide.md` (250 줄)
+- 안티패턴 5종 포함
+
+### 산출물
+
+- `workflow_kit/contract_v1/delegator.py` 확장 (~340 줄)
+- `workflow_kit/contract_v1/output_validator.py` 확장 (~280 줄)
+- `workflow_kit/contract_v1/__init__.py` export 추가
+- `core/orchestrator_subagent_contract_v1.md` spec 확장
+- `core/orchestrator_contract_v1_wire_guide.md` (신규)
+- `tests/check_contract_v1_multi_component.py` (신규, 17 check)
+- `tests/check_contract_v1_delegator.py` 확장 (4 model_tier check)
+- `tests/check_contract_v1_direct_only.py` 확장 (DIRECT_ONLY_ACTIONS 9개)
+- `releases/Beta-v0.5.7.md`
+
+### 회귀
+
+- check_contract_v1_multi_component.py: 17/17 PASS
+- check_contract_v1_delegator.py: 4 mapping + 9 rejection + 4 model_tier PASS
+- check_contract_v1_direct_only.py: 9 actions PASS
+- check_docs.py: 111/111 PASS
+- 5개 v0.5.5/v0.5.6 contract v1 회귀 그대로 PASS
+
+### spec 갭 (v0.5.7)
+
+1. sub_result status enum → `ok` / `partial` / `failed` (parent 와 동일)
+2. parent_delegation_id 위치 → §5 output top-level (sub_results 있으면 필수)
+
+### 다음
+
+- v0.5.7 PR #21 (예정) 머지
+- v0.5.7-beta 태그 push
+- v0.5.8 후보: Mavis 측 자동 wire, PyPI 배포, fan-out/in pilot walkthrough

--- a/ai-workflow/memory/release/v0.5.7/session_handoff.md
+++ b/ai-workflow/memory/release/v0.5.7/session_handoff.md
@@ -1,0 +1,82 @@
+# Session Handoff — v0.5.7
+
+- 문서 목적: v0.5.7 릴리스의 세션 인계 — 완료 상태, 변경 파일, 회귀 baseline, Mavis 측 핵심 결정
+- 범위: v0.5.7 PR #21 머지 직전 작업물의 상태 스냅샷
+- 대상 독자: 다음 세션 오케스트레이터 (Mavis), v0.5.8 작업을 시작하는 maintainer
+- 상태: stable (v0.5.7 ship 직전)
+- 최종 수정일: 2026-06-08
+- 관련 문서: [릴리스 노트 v0.5.7](../../../../workflow-source/releases/Beta-v0.5.7.md), [이전 handoff v0.5.6](../v0.5.6/session_handoff.md), [Wire 가이드](../../../../workflow-source/core/orchestrator_contract_v1_wire_guide.md)
+
+---
+
+- 일자: 2026-06-08
+- 브랜치: `release/v0.5.7`
+- 후속 작업자: 다음 세션 오케스트레이터
+- 이전 handoff: [`../v0.5.6/session_handoff.md`](../v0.5.6/session_handoff.md)
+
+## 1. v0.5.7 완료 상태
+
+- 4 sub-task 모두 완료:
+  - TASK-V057-001-A: contract v1 §4.2/§5.2 multi-component fan-out/in (delegator.choose_roles + output_validator.validate_fanin_output)
+  - TASK-V057-001-B: §6.3 cross-ref 갱신 / fan-in 통합 row 추가 (MUST_NOT_DELEGATE_MARKERS 7→9)
+  - TASK-V057-001-C (P2): required_model_tier + recommend_model_tier 자동 main/small 결정
+  - TASK-V057-001-D (P2): artifacts[].action (created/modified/deleted) + added/removed/total 분리
+  - 추가: Mavis 측 wire 가이드 [`core/orchestrator_contract_v1_wire_guide.md`](../../../../workflow-source/core/orchestrator_contract_v1_wire_guide.md) (250 줄)
+- 회귀: 7 contract v1 + 111 docs 모두 PASS
+
+## 2. 변경된 파일 (v0.5.7)
+
+신규:
+- `workflow-source/core/orchestrator_contract_v1_wire_guide.md` (Mavis wire 가이드)
+- `workflow-source/tests/check_contract_v1_multi_component.py` (17 check)
+
+확장:
+- `workflow-source/core/orchestrator_subagent_contract_v1.md` (spec §4.2/§5.2 + §6.3 row 2개 + §4.1/§5.1 필드 + §9.0 helpers)
+- `workflow-source/workflow_kit/contract_v1/__init__.py` (export 추가)
+- `workflow-source/workflow_kit/contract_v1/delegator.py` (choose_roles, recommend_model_tier, MAIN_TIER_KEYWORDS, MUST_NOT_DELEGATE_MARKERS 7→9)
+- `workflow-source/workflow_kit/contract_v1/output_validator.py` (validate_fanin_output, artifacts action+stats, REQUIRED_SUB_RESULT_FIELDS)
+- `workflow-source/tests/check_contract_v1_delegator.py` (4 model_tier check 추가)
+- `workflow-source/tests/check_contract_v1_direct_only.py` (DIRECT_ONLY_ACTIONS 7→9)
+- `workflow-source/releases/Beta-v0.5.7.md` (릴리스 노트)
+- `ai-workflow/memory/release/v0.5.7/*` (메모리 layer 동기화)
+
+## 3. 회귀 baseline (v0.5.7)
+
+| 회귀 | 결과 |
+| --- | --- |
+| `check_bootstrap.py` | ⚠️ env 의존 (main 과 동일) |
+| `check_bootstrap_mcp_roundtrip.py` | ✅ 5/5 |
+| `check_docs.py` | ✅ 111/111 |
+| `check_contract_v1_roundtrip.py` | ✅ |
+| `check_contract_v1_role_mapping.py` | ✅ |
+| `check_contract_v1_direct_only.py` | ✅ (9 actions) |
+| `check_contract_v1_output_validator.py` | ✅ (4 pilot + 8 violation + 4 pilot doc) |
+| `check_contract_v1_delegator.py` | ✅ (4 mapping + 9 rejection + 4 model_tier) |
+| `check_contract_v1_multi_component.py` (신규) | ✅ (17 check) |
+| `check_pilot_phase11_contract_v1.py` | ✅ |
+| `check_workflow_linter.py` | ⚠️ env 의존 (main 과 동일) |
+
+## 4. v0.5.7 핵심 결정 (Mavis 가 다음 세션에 알려야 할 것)
+
+- **§6.3 marker 9개** (7 + cross-ref + fan-in 통합): sub-agent 가 cross-ref 갱신 / fan-in 통합 보고 작성 시도 시 자동 reject
+- **fan-out 결정은 항상 delegator 사용**: `choose_roles(task, strict=True)` 가 §6.3 위반 sub 까지 자동 검출
+- **fan-in 통합 보고는 항상 orchestrator 작성**: sub-agent 는 자기 sub 만 보고 (`sub_results[]`), orchestrator 가 fan-in 페이로드 합성
+- **model_tier 자동 결정**: sub-agent 가 worker.model_tier 를 자동 결정 X, orchestrator 의 `decision.recommended_model_tier` 사용
+- **Mavis 측 wire**: `orchestrator_contract_v1_wire_guide.md` 의 안티패턴 5종 회피
+
+## 5. 다음 세션 진입 시 확인
+
+- v0.5.7 PR #21 (예정) 머지 완료 확인
+- v0.5.7-beta 태그 push 확인
+- `mavis communication send --to mvs_a96f8eb4990a482ca14e3e5223447bb7 --command prompt` 로 메모리 동기화 알림
+- v0.5.8 후보 (Mavis 측 wire 자동화, PyPI 배포, fan-out/in pilot walkthrough) 시작 가능
+
+## 6. v0.5.5 → v0.5.7 핵심 진화
+
+| 축 | v0.5.5 | v0.5.6 | v0.5.7 |
+| --- | --- | --- | --- |
+| Enforcement | paper (회귀 baseline X) | P0 enforce (validator + delegator) | P1/P2 enforce (fan-out/in + model_tier + cross-ref) |
+| Sub-agent 검출 | spec 4개 role | 7 §6.3 marker | 9 §6.3 marker (cross-ref/fan-in 통합) |
+| 결과 검증 | manual | 9 §5 필드 | + 4 sub_result 필드 + 3 artifact action+stats |
+| 위임 결정 | orchestrator 손 | choose_role 자동 | + choose_roles fan-out + recommend_model_tier |
+| Pilot | 4 single-task | 4 회귀 baseline | + 17 multi-component 회귀 |

--- a/ai-workflow/memory/release/v0.5.7/state.json
+++ b/ai-workflow/memory/release/v0.5.7/state.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-06-08T22:00:00+09:00",
+  "release": "v0.5.7",
+  "status": "shipped",
+  "tasks": [
+    {
+      "id": "TASK-V057-001",
+      "name": "Contract v1 §4.2/§5.2 multi-component fan-out/in + §6.3 cross-ref row",
+      "status": "done",
+      "branch": "release/v0.5.7",
+      "sub_tasks": [
+        {"id": "A", "name": "§4.2/§5.2 fan-out/in (delegator.choose_roles + validate_fanin_output)", "status": "done"},
+        {"id": "B", "name": "§6.3 cross-ref 갱신 / fan-in 통합 row 추가", "status": "done"},
+        {"id": "C", "name": "P2: required_model_tier + recommend_model_tier 자동 main/small", "status": "done"},
+        {"id": "D", "name": "P2: artifacts[].action + added/removed/total 분리", "status": "done"}
+      ],
+      "deliverables": [
+        "workflow_kit/contract_v1/delegator.py (choose_roles, recommend_model_tier, MAIN_TIER_KEYWORDS, 9 markers)",
+        "workflow_kit/contract_v1/output_validator.py (validate_fanin_output, REQUIRED_SUB_RESULT_FIELDS, ALLOWED_ARTIFACT_ACTIONS)",
+        "workflow_kit/contract_v1/__init__.py (export 추가)",
+        "core/orchestrator_subagent_contract_v1.md (§4.2/§5.2/§6.3 row 2개/§4.1/§5.1 fields)",
+        "core/orchestrator_contract_v1_wire_guide.md (Mavis wire 가이드, 250 줄)",
+        "tests/check_contract_v1_multi_component.py (17 check, 신규)",
+        "tests/check_contract_v1_delegator.py (4 model_tier check 추가)",
+        "tests/check_contract_v1_direct_only.py (DIRECT_ONLY_ACTIONS 9개)",
+        "releases/Beta-v0.5.7.md"
+      ]
+    }
+  ],
+  "regressions": {
+    "contract_v1": {
+      "roundtrip": "pass",
+      "role_mapping": "pass",
+      "direct_only_9_actions": "pass",
+      "output_validator": "pass",
+      "delegator_with_model_tier": "pass",
+      "multi_component_17": "pass",
+      "pilot_phase11": "pass"
+    },
+    "docs": "111/111 pass",
+    "bootstrap": "env-dependent (main과 동일, v0.5.7 범위 밖)",
+    "linter": "env-dependent (main과 동일, v0.5.7 범위 밖)"
+  },
+  "spec_gaps_v057": [
+    {
+      "gap": "sub_result status enum",
+      "resolution": "parent status enum과 동일 (ok/partial/failed) — spec §5.2 명시"
+    },
+    {
+      "gap": "parent_delegation_id location",
+      "resolution": "§5 output top-level (sub_results 있으면 필수)"
+    }
+  ],
+  "next_release_candidates": [
+    "Mavis 측 choose_role/choose_roles 자동 wire (mavis-team hook)",
+    "PyPI 배포",
+    "fan-out/in pilot walkthrough (Devhub N+1 endpoint)",
+    "contract v2 streaming/observability"
+  ]
+}

--- a/workflow-source/core/orchestrator_contract_v1_wire_guide.md
+++ b/workflow-source/core/orchestrator_contract_v1_wire_guide.md
@@ -1,0 +1,214 @@
+# Mavis / Mavis Orchestrator → Contract v1 Wire 가이드 (v0.5.7)
+
+> standard_ai_workflow 의 contract v1 enforcement 헬퍼(`workflow_kit.contract_v1`)를 Mavis / Mavis 같은 메인 오케스트레이터 런타임이 **실제 위임 결정 경로**에 묶는 패턴 가이드. v0.5.6 부터 모듈은 stable, v0.5.7 부터 fan-out/in wire 까지 포함.
+
+## 1. 왜 wire 가이드가 필요한가
+
+v0.5.6 의 `choose_role` / `validate_output` 은 **순수 Python 모듈** — 자동 enforce 가능하지만 orchestrator 가 명시적으로 호출해야 동작. v0.5.5 pilot 에서 4 시나리오 round-trip 은 PASS 였지만, **회귀 검증**이 자동화되어 있지 않아 "원칙적으로 강제" 만 되고 "실제 매 호출마다 강제" 되진 않았음.
+
+v0.5.6 부터 회귀 스크립트(`check_contract_v1_delegator.py` / `check_contract_v1_output_validator.py`) 가 "강제 안 하면 PASS" 인 baseline 을 자동 검증. v0.5.7 부터 fan-out/in 도 동일.
+
+본 가이드는 Mavis / Mavis 가 `choose_role` / `choose_roles` / `validate_output` / `validate_fanin_output` 을 **실제 sub-agent 호출 직전·직후**에 어떻게 wire 하는지 보여준다.
+
+## 2. Single-task 위임 패턴
+
+```python
+from workflow_kit.contract_v1 import (
+    choose_role,
+    validate_output,
+    DelegationRejected,
+    OutputValidationResult,
+)
+
+
+def delegate_to_subagent(task: dict, sub_agent_caller) -> dict:
+    """Standard single-task delegation with contract v1 enforcement."""
+    # 1) 위임 결정 (§6)
+    decision = choose_role(task)
+    if decision.must_not_delegate:
+        # §6.3 — orchestrator 직접 처리
+        raise DelegationRejected(decision)
+
+    # 2) sub-agent 호출 (§4 입력 페이로드에 decision.delegation_id 주입)
+    payload = {
+        "contract_version": "1.0",
+        "delegation_id": decision.delegation_id,
+        # ... (issued_by, task, context 등 §4 스키마 채움)
+    }
+    response = sub_agent_caller(payload)
+
+    # 3) 출력 검증 (§5)
+    result: OutputValidationResult = validate_output(
+        response,
+        expected_delegation_id=decision.delegation_id,
+    )
+    if not result.is_valid:
+        # §7.4 정책: 위반 보고 + 재위임 1회
+        log_violation(result.errors, decision.delegation_id)
+        raise OutputValidationFailed(result)
+
+    return response["result"]
+```
+
+## 3. Multi-component fan-out/in 패턴 (v0.5.7)
+
+```python
+from workflow_kit.contract_v1 import (
+    choose_roles,
+    validate_fanin_output,
+)
+
+
+def fanout_to_subs(task: dict, sub_agent_caller) -> dict:
+    """v0.5.7: 멀티 컴포넌트 fan-out + parent fan-in 패턴."""
+    # 1) fan-out 결정 (§4.2) — strict=True 면 §6.3 위반 시 raise
+    decisions = choose_roles(task, strict=True)
+    parent_decision = decisions[0]
+    sub_decisions = decisions[1:]
+
+    # 2) sub-agent 들을 병렬로 호출
+    sub_responses: list[dict] = []
+    for sub_decision in sub_decisions:
+        sub_payload = {
+            "contract_version": "1.0",
+            "delegation_id": sub_decision.delegation_id,
+            "parent_delegation_id": parent_decision.delegation_id,
+            "task": {
+                "sub_id": sub_decision.sub_id,
+                "task_type": sub_decision.task_type,
+                # ...
+            },
+        }
+        sub_responses.append(sub_agent_caller(sub_payload))
+
+    # 3) fan-in 보고서 작성 (sub-agent 가 아니라 orchestrator)
+    fanin_payload = {
+        "contract_version": "1.0",
+        "delegation_id": parent_decision.delegation_id,
+        "parent_delegation_id": parent_decision.delegation_id,
+        "completed_at": now_iso(),
+        "worker": {
+            "session_id": orchestrator_session_id(),
+            "role": parent_decision.role,
+            "model_tier": parent_decision.recommended_model_tier or "small",
+        },
+        "result": {
+            "status": aggregate_status([r["result"]["status"] for r in sub_responses]),
+            "summary": fanin_summary(sub_responses),
+            "artifacts": fanin_artifacts(sub_responses),
+            "written_paths": fanin_written_paths(sub_responses),
+            "sub_results": [
+                {
+                    "sub_id": sub["task"]["sub_id"],
+                    "delegation_id": sub["delegation_id"],
+                    "status": r["result"]["status"],
+                    "summary": r["result"]["summary"],
+                    "written_paths": r["result"]["written_paths"],
+                }
+                for sub, r in zip(sub_payloads, sub_responses)
+            ],
+            "next_step": orchestrator_next_step(sub_responses),
+        },
+    }
+
+    # 4) fan-in 검증 (§5.2)
+    result = validate_fanin_output(
+        fanin_payload,
+        expected_parent_delegation_id=parent_decision.delegation_id,
+    )
+    if not result.is_valid:
+        # aggregated status mismatch / sub delegation_id prefix mismatch 등
+        log_violation(result.errors, parent_decision.delegation_id)
+        raise OutputValidationFailed(result)
+
+    return fanin_payload
+```
+
+## 4. model_tier 결정 (v0.5.7)
+
+```python
+from workflow_kit.contract_v1 import choose_role, recommend_model_tier
+
+
+def delegate_with_model_tier(task: dict) -> DelegationDecision:
+    """v0.5.7: 자동 main/small 결정 + 명시 override 존중."""
+    decision = choose_role(task)
+    if decision.must_not_delegate:
+        return decision
+    # decision.recommended_model_tier 가 자동 결정값 (small / main)
+    # task.required_model_tier 가 명시되어 있으면 그게 우선
+    actual_tier = decision.recommended_model_tier
+    return decision
+
+
+# main 후보 keyword (delegator 내부 정의):
+# - "아키텍처", "정책", "5+ 파일", "cross-cutting", "5+ source"
+# main 이 default 로 매핑되는 경우: 위 keyword 가 task.brief / constraints /
+# must_include 에 등장하면 main, 아니면 small.
+```
+
+## 5. Mavis 측 권장 wiring 지점
+
+Mavis / Mavis 가 sub-agent 위임을 결정하는 함수는 보통 다음 두 곳 중 하나:
+
+| 지점 | Mavis 함수 (개념) | wire |
+| --- | --- | --- |
+| Task 라우팅 (delegation 결정) | `should_delegate(task) → bool` | `choose_role(task)` 호출로 대체. `must_not_delegate=True` 면 False (직접 처리) |
+| Tool 사용 결정 | `execute_tool(name, args)` | 도구 호출 직전에 task 를 합성해서 `choose_role` 통과 여부 확인 |
+
+### 5.1 minimal wire (Mavis 측 의사 코드)
+
+```python
+# mavis/orchestrator.py (개념)
+from workflow_kit.contract_v1 import choose_role, DelegationRejected
+
+
+def mavis_delegate(task: dict) -> DelegationDecision:
+    """Mavis 가 task 를 받으면 무조건 choose_role 부터 호출."""
+    decision = choose_role(task)
+    if decision.must_not_delegate:
+        # §6.3: orchestrator 직접 처리 영역
+        return direct_handle(task, decision.rejected_reason)
+    # fan-out 후보: task.sub_tasks 가 있으면 choose_roles
+    if task.get("sub_tasks"):
+        sub_decisions = choose_roles(task, strict=True)
+        return fanout_to_subs(task, sub_decisions)
+    # 일반 single 위임
+    return delegate_to_subagent(task, decision)
+```
+
+## 6. 회귀 검증 (Mavis 통합 테스트)
+
+v0.5.6 의 `check_contract_v1_delegator.py` / `check_contract_v1_output_validator.py`, v0.5.7 의 `check_contract_v1_multi_component.py` 가 자동 enforce baseline. Mavis 측은 추가로:
+
+```bash
+# 위 3개 회귀 + bootstrap + mcp_roundtrip + pilot 을 CI 에서 매 PR 마다 실행
+python3 workflow-source/tests/check_contract_v1_delegator.py
+python3 workflow-source/tests/check_contract_v1_output_validator.py
+python3 workflow-source/tests/check_contract_v1_multi_component.py
+python3 workflow-source/tests/check_pilot_phase11_contract_v1.py
+```
+
+## 7. v0.5.7 신규 wire 포인트 요약
+
+| 신규 API | wire 시점 | 효과 |
+| --- | --- | --- |
+| `choose_roles(task, strict=...)` | sub-agent fan-out 결정 시 | sub_task 별 role + parent-prefix delegation_id 발급 |
+| `validate_fanin_output(payload, expected_parent_delegation_id=...)` | sub-agent fan-in 보고 수신 시 | aggregated status 일관성 + sub delegation_id prefix enforce |
+| `recommend_model_tier(task)` | `choose_role` 결과 확인 시 | task keyword 기반 main/small 자동 결정 |
+| `decision.recommended_model_tier` | sub-agent 호출 페이로드 생성 시 | worker.model_tier 자동 주입 |
+| `decision.sub_id` | sub-agent 호출 결과 routing 시 | multi-component 결과 → 원본 sub 매핑 |
+
+## 8. 안티패턴 (피해야 할 wire)
+
+1. **`choose_role` 호출 없이 sub-agent 직접 spawn** — contract v1 우회. 회귀가 빨간불이어야 함.
+2. **sub-agent 가 fan-in 보고서를 작성** — §6.3 의 "fan-in 통합 보고는 orchestrator" 위반. orchestrator 만 fan-in.
+3. **`sub_results` 를 무시하고 sub 응답을 통째로 합치기** — §5.2 의 aggregated status 계산이 무의미해짐. `validate_fanin_output` 의 status consistency check 가 잡아냄.
+4. **`expected_delegation_id` 없이 `validate_output` 호출** — cross-delegation leak (sub-agent 가 다른 delegation_id 응답) 못 잡음.
+5. **model_tier 를 sub-agent 가 자기 결정** — §4.1 의 `required_model_tier` 가 orchestrator 결정값. sub-agent 가 무시 가능하지만 자동 검증.
+
+## 9. 다음 단계
+
+- Mavis 측 `mavis_team` (engine) 의 `mavis communication send --command spawn` 호출 직전에 `choose_role` 자동 wire
+- mavis-team 의 `delegate_to_subagent` hook 에서 `validate_output` enforce
+- v0.5.8 에서 PyPI 배포 + 위 hook 들의 mavis 표준 wiring

--- a/workflow-source/core/orchestrator_subagent_contract_v1.md
+++ b/workflow-source/core/orchestrator_subagent_contract_v1.md
@@ -1,10 +1,10 @@
 # Orchestrator ↔ Sub-agent Delegation Contract v1
 
 - 문서 목적: 메인 오케스트레이터(세션 루트 세션)가 sub-agent 워커에게 작업을 위임할 때 따르는 외부 contract v1 을 명시한다. 이 contract 는 standard_ai_workflow v0.5.4 부터 적용되며, [이슈 #1](https://github.com/ykylee/standard_ai_workflow/issues/1) ("오케스트레이터가 서브 에이전트를 호출하지 않고 직접 도구를 사용") 의 영구 해결을 위한 기준선이 된다.
-- 범위: 위임 입력/출력 스키마, 4개 역할 경계, 위임 가능/불가 카탈로그, 에러/폴백 정책, 검증 시나리오
+- 범위: 위임 입력/출력 스키마, 4개 역할 경계, 위임 가능/불가 카탈로그, 에러/폴백 정책, 검증 시나리오, 멀티 컴포넌트 fan-out/in (v0.5.7 부터)
 - 대상 독자: standard_ai_workflow 도입자, 멀티 에이전트 운영자, AI 에이전트 설계자
-- 상태: stable (v1, 2026-06-07)
-- 최종 수정일: 2026-06-07
+- 상태: stable (v1, 2026-06-08 — v0.5.7: §6.3 cross-ref row + §11 멀티 컴포넌트 1차 컷 + §4.1 required_model_tier + §5.1 sub_results fan-in)
+- 최종 수정일: 2026-06-08
 - 관련 문서:
   - 권장 운영 원칙: [./workflow_agent_topology.md](./workflow_agent_topology.md)
   - 공통 표준: [./global_workflow_standard.md](./global_workflow_standard.md)
@@ -166,9 +166,83 @@ contract v1 은 다음 4개 역할을 정의한다. 각 역할은 책임, 권한
 | `task.validation.criteria` | string | ❌ | 검증 기준 (linter/test PASS 등) |
 | `task.validation.owner` | enum | ✅ | 항상 `"orchestrator"` (검증 책임 명시) |
 | `task.deadline_hint` | ISO 8601 | ❌ | 권장 완료 시각, 강제 X |
+| `task.required_model_tier` | enum | ❌ | v0.5.7: `"small"` (기본) / `"main"` (강제 승격). 미지정 시 `delegator` 가 자동 결정 (main 후보: 아키텍처 변경, 정책 결정, 5+ 파일 cross-cutting, bounded_research 5+ source) |
+| `task.parent_delegation_id` | string | ❌ | v0.5.7: 멀티 컴포넌트 fan-out 시 부모 delegation_id. 미지정 시 standalone 으로 간주 |
+| `task.sub_tasks` | object[] | ❌ | v0.5.7: fan-out 의 분해된 sub-task 목록 (아래 §4.2 참조) |
 | `context.branch` | string | ✅ | git branch |
 | `context.memory_layer_root` | path | ❌ | 메모리 layer 루트 |
 | `context.project_root` | path | ✅ | 절대 경로 |
+
+### 4.2 멀티 컴포넌트 sub-task (v0.5.7, fan-out)
+
+복합 작업을 여러 sub-agent 가 분담할 때 사용하는 fan-out 입력. **부모 task 의 `sub_tasks` 필드**에 1개 이상의 sub-task 정의. 각 sub-task 는 §4 의 task 본질을 그대로 따른다 (스키마 동일). 부모 sub-agent 또는 orchestrator 가 fan-out 결정, sub-agent 가 fan-in 보고.
+
+```json
+{
+  "contract_version": "1.0",
+  "delegation_id": "del-2026-06-08-fanout-001",
+  "issued_at": "2026-06-08T15:00:00+09:00",
+  "issued_by": {
+    "session_id": "mvs_orchestrator_root",
+    "role": "orchestrator"
+  },
+  "task": {
+    "task_id": "TASK-V057-001",
+    "task_type": "code_change",
+    "brief": "Devhub N+1 endpoint 1차 구현 + 4 시나리오 동시 진행",
+    "constraints": ["scope: backend-core/handlers/"],
+    "sub_tasks": [
+      {
+        "sub_id": "st-1",
+        "task_type": "code_change",
+        "brief": "POST /auth/logout 구현 (OIDC + 204)",
+        "primary_artifact": "backend-core/handlers/auth_logout.go",
+        "artifact_kind": "code",
+        "parent_delegation_id": "del-2026-06-08-fanout-001"
+      },
+      {
+        "sub_id": "st-2",
+        "task_type": "code_change",
+        "brief": "POST /ci-runs 구현 (repository_id + 7 enum + 409 idempotency)",
+        "primary_artifact": "backend-core/handlers/ci_runs.go",
+        "artifact_kind": "code",
+        "parent_delegation_id": "del-2026-06-08-fanout-001"
+      },
+      {
+        "sub_id": "st-3",
+        "task_type": "validation_run",
+        "brief": "4 endpoint 통합 test suite 실행",
+        "primary_artifact": "backend-core/tests/contract_v1_integration.py",
+        "artifact_kind": "code",
+        "parent_delegation_id": "del-2026-06-08-fanout-001"
+      }
+    ],
+    "expected_outputs": {
+      "primary_artifact": "backend-core/handlers/",
+      "artifact_kind": "code",
+      "must_include": ["3 sub-component 모두 PASS", "fan-in aggregation 1 report"]
+    }
+  }
+}
+```
+
+#### 4.2.1 sub-task 필드 정의
+
+| 필드 | 타입 | 필수 | 설명 |
+| --- | --- | --- | --- |
+| `sub_id` | string | ✅ | 부모 내 유니크 (`st-N` 권장) |
+| `task_type` | enum | ✅ | 부모와 독립 — 각 sub-task 별 role 결정 |
+| `brief` | string | ✅ | sub-task 설명 |
+| `primary_artifact` | path | ✅ | sub 산출물 |
+| `artifact_kind` | enum | ✅ | `markdown` / `python` / `json` / `toml` / `text` / `code` / `other` |
+| `parent_delegation_id` | string | ✅ | 부모 delegation_id 와 일치해야 함 (delegator 가 enforce) |
+
+#### 4.2.2 fan-out 규칙
+
+- `sub_tasks` 가 1개 이상이면 **반드시 fan-out 모드** (단일 위임 아님)
+- 각 sub-task 는 §4 의 task 본질을 따르므로 `delegator.choose_role` 을 각각 호출 가능 (per-sub delegation_id 별도)
+- sub-task 별 `delegation_id` 형식: `del-YYYY-MM-DD-<parent-suffix>-<sub_id>` 권장
+- `sub_tasks` 내 `task_type` 이 부모와 다를 수 있음 (e.g. 부모 `code_change` + sub `validation_run` 혼재 가능)
 
 ## 5. 위임 출력 스키마 (sub-agent → orchestrator)
 
@@ -236,6 +310,8 @@ sub-agent 가 작업을 끝내고 orchestrator 에게 보고할 때 사용하는
 | `result.next_step` | string | ✅ | orchestrator 가 다음에 할 일 |
 | `warnings` | string[] | ❌ | 단서, 가정, 한계 |
 | `risks` | string[] | ❌ | 후속 작업 시 주의 |
+| `sub_results` | object[] | ❌ | v0.5.7: fan-in 보고. sub-task 별 §5 보고 (아래 §5.2 참조) |
+| `parent_delegation_id` | string | ❌ | v0.5.7: fan-in 보고 시 부모 delegation_id. `sub_results` 가 있으면 필수 |
 
 ## 6. 위임 가능 / 불가 카탈로그
 
@@ -273,6 +349,9 @@ sub-agent 가 작업을 끝내고 orchestrator 에게 보고할 때 사용하는
 | PR 본문 작성 | orchestrator | 사용자-facing 메시지 |
 | 짧은 triage read (1 파일, 50줄 미만) | orchestrator | 컨텍스트 부풀림 작음 |
 | 메모리 layer 의 session_handoff.md / state.json 직접 write | orchestrator | 단일 진실 공급원 |
+| **cross-ref 갱신 (docs/ ↔ memory layer ↔ handoff 간 링크 수정)** (v0.5.7 신규) | orchestrator | cross-ref 는 단일 진실 공급원(orchestrator) 만이 일관성 보장 가능; sub-agent 가 부분 갱신 시 dead link 위험 |
+| **fan-in 결과 통합 보고 작성** (v0.5.7 신규) | orchestrator | sub_results 통합은 §6.3 의 "sub-agent 출력 통합/리뷰" 의 멀티 컴포넌트 버전; sub-agent 가 자기 sub 만 보고, 통합은 orchestrator |
+| **parent_delegation_id 발급** (v0.5.7 신규) | orchestrator | fan-out 의 부모 ID 는 fan-out 결정의 일부, orchestrator 만 발급 |
 
 ### 6.4 위임 금지 영역
 
@@ -377,9 +456,81 @@ v0.5.5 TASK-V055-001 의 S4 라이브 데모는 4 시나리오 contract v1 round
 v0.5.6 부터 contract v1 의 §5/§6 enforcement 가 Python 모듈로 제공된다:
 
 - **§5 출력 검증**: `workflow_kit.contract_v1.output_validator.validate_output(payload, expected_delegation_id=None) -> OutputValidationResult`
+- **§5 fan-in 검증** (v0.5.7): `workflow_kit.contract_v1.output_validator.validate_fanin_output(payload, expected_parent_delegation_id=None) -> OutputValidationResult`. `sub_results[]` 각 항목도 재귀 검증
 - **§6 위임 결정**: `workflow_kit.contract_v1.delegator.choose_role(task, strict=False) -> DelegationDecision`
+- **§6 멀티 위임 (fan-out, v0.5.7)**: `workflow_kit.contract_v1.delegator.choose_roles(task, strict=False) -> list[DelegationDecision]`. `task.sub_tasks` 가 있으면 각 sub-task 에 대해 호출; 없으면 단일 결과 (`[choose_role(task)]`)
+- **§6 model_tier 자동 결정 (v0.5.7)**: `workflow_kit.contract_v1.delegator.recommend_model_tier(task) -> "small" | "main"`. main 후보: 아키텍처 결정, 정책 문구, 5+ 파일 cross-cutting, bounded_research 5+ source
 
-오케스트레이터 / sub-agent 런타임은 이 헬퍼를 호출해서 contract v1 을 자동 enforce 한다. 자세한 사용 예시는 [`workflow_kit/contract_v1/__init__.py`](../../workflow_kit/contract_v1/__init__.py) 와 회귀 [`check_contract_v1_output_validator.py`](../../tests/check_contract_v1_output_validator.py) / [`check_contract_v1_delegator.py`](../../tests/check_contract_v1_delegator.py) 참조.
+### 5.2 fan-in 출력 스키마 (sub-agent fan-in 보고, v0.5.7)
+
+멀티 컴포넌트 작업의 부모 sub-agent 가 fan-in 보고할 때 사용. 각 sub-task 별 §5 보고를 `sub_results[]` 에 담고, 부모 보고의 `parent_delegation_id` 와 매칭.
+
+```json
+{
+  "contract_version": "1.0",
+  "delegation_id": "del-2026-06-08-fanout-001-parent",
+  "completed_at": "2026-06-08T17:30:00+09:00",
+  "worker": {
+    "session_id": "mvs_parent_xxxxxxxx",
+    "role": "code-worker",
+    "model_tier": "main"
+  },
+  "parent_delegation_id": "del-2026-06-08-fanout-001",
+  "result": {
+    "status": "ok",
+    "summary": "3 sub-component 모두 PASS, fan-in 통합 완료",
+    "artifacts": [
+      {"path": "backend-core/handlers/auth_logout.go", "kind": "code", "action": "created"},
+      {"path": "backend-core/handlers/ci_runs.go", "kind": "code", "action": "created"},
+      {"path": "backend-core/tests/contract_v1_integration.py", "kind": "python", "action": "created"}
+    ],
+    "written_paths": [
+      "backend-core/handlers/auth_logout.go",
+      "backend-core/handlers/ci_runs.go",
+      "backend-core/tests/contract_v1_integration.py"
+    ],
+    "sub_results": [
+      {
+        "sub_id": "st-1",
+        "delegation_id": "del-2026-06-08-fanout-001-st-1",
+        "status": "ok",
+        "summary": "POST /auth/logout OIDC + 204 구현, 5/5 test PASS",
+        "written_paths": ["backend-core/handlers/auth_logout.go"]
+      },
+      {
+        "sub_id": "st-2",
+        "delegation_id": "del-2026-06-08-fanout-001-st-2",
+        "status": "ok",
+        "summary": "POST /ci-runs repository_id + 7 enum + 409 idempotency, 4/4 test PASS",
+        "written_paths": ["backend-core/handlers/ci_runs.go"]
+      },
+      {
+        "sub_id": "st-3",
+        "delegation_id": "del-2026-06-08-fanout-001-st-3",
+        "status": "partial",
+        "summary": "integration 12/15 PASS — 3개 race condition 발견, fix 위임 필요",
+        "written_paths": ["backend-core/tests/contract_v1_integration.py"]
+      }
+    ],
+    "validation_result": {
+      "ran": true,
+      "command": "pytest backend-core/tests/contract_v1_integration.py -q",
+      "status": "partial",
+      "details": "12/15 PASS, 3 fail (st-3 race)"
+    },
+    "next_step": "orchestrator 가 st-3 race fix 를 code-worker 에 별도 위임 후 fan-in 재보고"
+  }
+}
+```
+
+#### 5.2.1 fan-in 규칙
+
+- `sub_results` 가 있으면 `parent_delegation_id` 필수
+- 각 sub_result 항목은 `sub_id` + `delegation_id` + `status` + `summary` + `written_paths` 최소 5필드
+- `result.status` 는 sub_results 의 status 들로부터 자동 계산 가능 (모든 `ok` → `ok`, 하나라도 `failed` → `failed`, 그 외 → `partial`)
+- `validate_fanin_output` 이 이 계산을 검증
+
+오케스트레이터 / sub-agent 런타임은 이 헬퍼를 호출해서 contract v1 을 자동 enforce 한다. 자세한 사용 예시는 [`workflow_kit/contract_v1/__init__.py`](../../workflow_kit/contract_v1/__init__.py) 와 회귀 [`check_contract_v1_output_validator.py`](../../tests/check_contract_v1_output_validator.py) / [`check_contract_v1_delegator.py`](../../tests/check_contract_v1_delegator.py) / [`check_contract_v1_multi_component.py`](../../tests/check_contract_v1_multi_component.py) (v0.5.7 신규) 참조. Mavis / Mavis 측 wire 패턴은 [`orchestrator_contract_v1_wire_guide.md`](./orchestrator_contract_v1_wire_guide.md) (v0.5.7 신규) 참조.
 
 ### 9.1 오케스트레이터 (Mavis) 측
 
@@ -411,12 +562,12 @@ v0.5.6 부터 contract v1 의 §5/§6 enforcement 가 Python 모듈로 제공된
 ## 11. 차기 버전 (v2 후보)
 
 contract v2 에서 다음 항목 검토:
-
 - 스트리밍 출력 (긴 작업 중간 progress 보고)
 - 양방향 ping (sub-agent 가 orchestrator 에 질문)
-- 멀티 sub-agent fan-out / fan-in
+- **멀티 sub-agent fan-out / fan-in** (v0.5.7 1차 컷: 입력 §4.2 + 출력 §5.2 + delegator `choose_roles` + §6.3 cross-ref row)
 - 에스크레이션 우선순위 (P0/P1/P2)
 - observability (각 delegation_id 별 latency / token 사용량 추적)
+- **required_model_tier 자동 결정** (v0.5.7 1차 컷: §4.1 필드 + delegator 자동 결정; v2 에서 policy 한 단계 더 formal 화)
 
 ## 다음에 읽을 문서
 

--- a/workflow-source/releases/Beta-v0.5.7.md
+++ b/workflow-source/releases/Beta-v0.5.7.md
@@ -1,0 +1,244 @@
+# Beta v0.5.7 — Contract v1 §4.2/§5.2 Multi-component Fan-out/In + §6.3 cross-ref Row
+
+- **릴리스 일자**: 2026-06-08
+- **브랜치**: `release/v0.5.7`
+- **포함 커밋**: v0.5.6 (PR #20) 이후 1 squash
+- **상태**: ✅ 1개 TASK 완료 (TASK-V057-001)
+
+## 1. 하이라이트
+
+v0.5.6 §5/§6 P0 enforcement 위에 v0.5.5 pilot P1/P2 priorities 2개 묶어서 enforce:
+
+- **TASK-V057-001-A**: contract v1 §4.2 sub_task fan-out / §5.2 sub_result fan-in (1차 컷) — `delegator.choose_roles(task, strict=False) -> list[DelegationDecision]`, `output_validator.validate_fanin_output(payload, expected_parent_delegation_id=None) -> OutputValidationResult`
+- **TASK-V057-001-B**: §6.3 "cross-ref 갱신" / "fan-in 통합 보고" row 추가 — delegator `MUST_NOT_DELEGATE_MARKERS` 7→9
+- **TASK-V057-001-C (P2)**: `task.required_model_tier` 필드 + `delegator.recommend_model_tier(task)` 자동 main/small 결정
+- **TASK-V057-001-D (P2)**: `result.artifacts[i].action` (created/modified/deleted) + `added/removed/total` 분리 validator
+- **신규 회귀 1개**: `check_contract_v1_multi_component.py` (7 choose_roles + 10 validate_fanin = 17 check)
+- **Mavis 측 wire 가이드**: [`orchestrator_contract_v1_wire_guide.md`](../core/orchestrator_contract_v1_wire_guide.md) (신규, ~250 줄) — Mavis / Mavis 가 `choose_role`/`choose_roles`/`validate_output`/`validate_fanin_output` 을 실제 위임 결정 경로에 묶는 패턴 + 안티패턴 5종
+
+## 2. TASK-V057-001-A: §4.2/§5.2 Multi-component Fan-out/In
+
+### 동기
+
+v0.5.5 pilot 의 4 시나리오는 모두 **single-task 위임** (PR #490/491/492/493 각자 1 delegation). v0.5.5 P1 도출: **multi-component sub-task** (e.g. Devhub N+1 endpoint 1차 구현 = 3 sub-task fan-out + fan-in 통합) 가 contract v1 spec 에 없음. v0.5.6 P1 priorities 1번: contract v2 fan-out/in — v0.5.7 에서 1차 컷.
+
+### 산출물
+
+[`workflow_kit/contract_v1/delegator.py`](../workflow_kit/contract_v1/delegator.py) (확장, ~340 줄, pure Python)
+
+신규 API:
+
+```python
+from workflow_kit.contract_v1 import choose_roles, validate_fanin_output, recommend_model_tier
+
+# §4.2 fan-out: sub_tasks 별 role 결정 + parent-prefix delegation_id
+decisions = choose_roles(task, strict=False)  # task.sub_tasks 가 있으면 fan-out
+parent = decisions[0]
+subs = decisions[1:]  # 각 sub: sub_id / delegation_id / role / model_tier
+
+# §5.2 fan-in: parent 보고 검증 + sub_results 집계 일관성
+result = validate_fanin_output(
+    fanin_payload,
+    expected_parent_delegation_id=parent.delegation_id,
+)
+if not result.is_valid:
+    # aggregated status mismatch / sub delegation_id prefix mismatch / missing sub fields
+    for err in result.errors:
+        log(f"{err.field}: {err.reason}")
+
+# P2: model_tier 자동 결정
+tier = recommend_model_tier(task)  # "small" (default) / "main" (아키텍처, 정책, 5+ 파일 등)
+```
+
+검증 항목 (총 27 + 회귀 1개):
+
+| 영역 | 항목 | 신규 |
+| --- | --- | --- |
+| `choose_roles` | sub_tasks 없으면 단일 결과 (`[choose_role(task)]`) | v0.5.7 |
+| `choose_roles` | N sub × parent + 1 = N+1 decisions | v0.5.7 |
+| `choose_roles` | parent §6.3 위반 → non-strict: must_not_delegate decision / strict: raise | v0.5.7 |
+| `choose_roles` | sub §6.3 위반 → v0.5.7 spec §6.3: sub marker 도 parent reject | v0.5.7 |
+| `choose_roles` | sub schema invalid (필수 필드 누락, 잘못된 task_type) → ValueError | v0.5.7 |
+| `validate_fanin_output` | sub_results 의 status 집계 → parent status 일관성 | v0.5.7 |
+| `validate_fanin_output` | parent_delegation_id 매치 (expected vs declared) | v0.5.7 |
+| `validate_fanin_output` | sub_result.delegation_id 가 parent prefix 로 시작 | v0.5.7 |
+| `validate_fanin_output` | sub_results 필수 필드 5개 (sub_id, delegation_id, status, summary, written_paths) | v0.5.7 |
+| `recommend_model_tier` | main keyword (아키텍처, 정책, 5+ 파일, cross-cutting, 5+ source) 매치 → "main" | v0.5.7 |
+| `recommend_model_tier` | 명시 `task.required_model_tier` → override | v0.5.7 |
+| `choose_role.recommended_model_tier` | 자동 결정값이 decision 에 박힘 | v0.5.7 |
+
+### 회귀
+
+[`tests/check_contract_v1_multi_component.py`](../tests/check_contract_v1_multi_component.py) (신규, 17 check)
+
+- choose_roles: 7 check (single/3-sub/parent-reject/strict/sub-reject/schema-invalid/type-invalid)
+- validate_fanin_output: 10 check (ok/partial/failed aggregation, status mismatch, parent mismatch, sub delegation_id prefix mismatch, missing sub field, missing parent, artifact action+stats, invalid action, invalid stat type)
+
+## 3. TASK-V057-001-B: §6.3 Cross-ref 갱신 / Fan-in 통합 Row 추가
+
+### 동기
+
+v0.5.6 P1 priorities 2번: "§6.1 cross-ref 갱신 명시 row 추가". v0.5.5 pilot 에서 `handoff / state.json / backlog` 3 marker 만으로는 부족. **문서 간 cross-link 수정** (e.g. workflow_agent_topology.md ↔ orchestrator_subagent_contract_v1.md ↔ memory layer) 과 **fan-in 통합 보고 작성** 도 sub-agent 가 처리하면 dead link / inconsistent integration 위험.
+
+### 변경
+
+| §6.3 row | 처리 주체 | 이유 (v0.5.7 추가) |
+| --- | --- | --- |
+| cross-ref 갱신 (docs/ ↔ memory layer ↔ handoff 간 링크 수정) | orchestrator | cross-ref 는 단일 진실 공급원(orchestrator) 만이 일관성 보장 가능; sub-agent 가 부분 갱신 시 dead link 위험 |
+| fan-in 결과 통합 보고 작성 | orchestrator | sub_results 통합은 §6.3 의 "sub-agent 출력 통합/리뷰" 의 멀티 컴포넌트 버전; sub-agent 가 자기 sub 만 보고, 통합은 orchestrator |
+| parent_delegation_id 발급 | orchestrator | fan-out 의 부모 ID 는 fan-out 결정의 일부, orchestrator 만 발급 |
+
+### Delegator 변경
+
+`MUST_NOT_DELEGATE_MARKERS` 7→9:
+
+```python
+MUST_NOT_DELEGATE_MARKERS = (
+    "handoff",
+    "backlog",
+    "state.json",
+    "ask_user",
+    "우선순위",
+    "통합/리뷰",
+    "PR 본문",
+    # v0.5.7 신규
+    "cross-ref",   # cross-ref 갱신은 orchestrator 직접 처리
+    "fan-in 통합", # fan-in 통합 보고는 orchestrator 직접 처리
+)
+```
+
+매치 검사도 확장: `sub_tasks[].brief` 까지 haystack 에 포함 → fan-out 결정 시 sub 의 §6.3 marker 도 parent reject (sub 가 fan-out 의 일부이므로 정합성).
+
+## 4. TASK-V057-001-C (P2): `required_model_tier` 자동 결정
+
+### 동기
+
+v0.5.5 pilot 의 4 시나리오 중 PR #492 (N:M weight, multi-file) 만 main 승격 (나머지 small). v0.5.5 P2 도출: model_tier 결정을 sub-agent 가 아니라 orchestrator 가 자동 enforce.
+
+### 변경
+
+- §4.1 input schema 에 `task.required_model_tier` (optional, "small" / "main") 추가
+- `delegator.recommend_model_tier(task)` 신규 API
+- main 후보 keyword 5개 (case-insensitive substring match against `task.brief` / `constraints` / `expected_outputs.must_include`):
+  - "아키텍처" (architecture)
+  - "정책" (policy)
+  - "5+ 파일" (5+ file cross-cutting)
+  - "cross-cutting"
+  - "5+ source" (bounded_research 5+ source)
+- 명시 `task.required_model_tier` 있으면 override
+- `choose_role` 결과의 `decision.recommended_model_tier` 필드에 자동 결정값 박힘
+
+## 5. TASK-V057-001-D (P2): `artifacts` Action + Stats 분리
+
+### 동기
+
+v0.5.5 pilot 의 PR #492 (N:M weight) 가 multi-file 변경. 단순 `path:kind` 만으로는 변경 통계 파악 어려움. P2 도출: `action` (created/modified/deleted) + `added/removed/total` 분리.
+
+### 변경
+
+`result.artifacts[i]` (optional, validated if present):
+
+| 필드 | 타입 | enum | 설명 |
+| --- | --- | --- | --- |
+| `action` | enum | `created` / `modified` / `deleted` | 변경 종류 (v0.5.7 신규) |
+| `added` | int | - | 추가된 줄 수 (v0.5.7 신규) |
+| `removed` | int | - | 삭제된 줄 수 (v0.5.7 신규) |
+| `total` | int | - | 최종 줄 수 (v0.5.7 신규) |
+
+기존 `path` / `kind` / `lines` 는 그대로 (backward compatible).
+
+## 6. Mavis 측 wire 가이드 (v0.5.7 신규)
+
+[`core/orchestrator_contract_v1_wire_guide.md`](../core/orchestrator_contract_v1_wire_guide.md) (신규, ~250 줄)
+
+핵심 패턴:
+
+```python
+# 1) Single-task 위임
+decision = choose_role(task)
+if decision.must_not_delegate:
+    raise DelegationRejected(decision)
+response = sub_agent_caller(payload)
+validate_output(response, expected_delegation_id=decision.delegation_id)
+
+# 2) Fan-out + Fan-in (v0.5.7)
+decisions = choose_roles(task, strict=True)
+parent = decisions[0]
+subs = decisions[1:]
+# ... sub-agent 병렬 호출
+fanin_payload = build_fanin(parent, sub_responses)
+validate_fanin_output(fanin_payload, expected_parent_delegation_id=parent.delegation_id)
+
+# 3) Mavis 측 안티패턴 5종
+# - choose_role 호출 없이 sub-agent 직접 spawn
+# - sub-agent 가 fan-in 보고서 작성
+# - sub_results 무시하고 통째 합치기
+# - expected_delegation_id 없이 validate_output 호출
+# - model_tier 를 sub-agent 가 자기 결정
+```
+
+## 7. 회귀 테스트 종합
+
+| 테스트 | 결과 |
+| --- | --- |
+| `check_bootstrap.py` (8 모드) | ⚠️ env 의존 (main 에서도 동일하게 fail; v0.5.7 범위 밖) |
+| `check_bootstrap_mcp_roundtrip.py` (5 하네스) | ✅ 5/5 |
+| `check_docs.py` | ✅ 111 markdown PASS |
+| `check_contract_v1_roundtrip.py` (S1) | ✅ |
+| `check_contract_v1_role_mapping.py` (S2) | ✅ |
+| `check_contract_v1_direct_only.py` (S3) | ✅ (9 MUST-NOT-delegate [7 v0.5.6 + 2 v0.5.7]) |
+| `check_contract_v1_output_validator.py` (v0.5.6 신규) | ✅ (4 pilot + 8 violation + 4 pilot doc) |
+| `check_contract_v1_delegator.py` (v0.5.6 확장) | ✅ (4 mapping + 9 rejection + strict + 4 model_tier) |
+| **`check_contract_v1_multi_component.py` (v0.5.7 신규)** | ✅ (7 choose_roles + 10 validate_fanin) |
+| `check_pilot_phase11_contract_v1.py` (v0.5.5) | ✅ |
+| `check_workflow_linter.py` | ⚠️ env 의존 (main 에서도 동일) |
+
+**v0.5.7 신규 회귀 1개 + v0.5.6 회귀 2개 (delegator 확장, direct_only 9개로) + v0.5.5/v0.5.4 회귀 그대로 PASS** = 회귀 7/7 + 111/111 docs.
+
+## 8. spec 갭 발견 (v0.5.7)
+
+`multi_component` 회귀 실행 중 1개 spec 갭 empirical 발견:
+
+| 필드 | Before | After |
+| --- | --- | --- |
+| `sub_result` 의 status (v0.5.7 spec §5.2) | 미정의 | `ok` / `partial` / `failed` (parent status 와 동일 enum) |
+| `parent_delegation_id` 위치 (v0.5.7 spec §5) | §4 input 만 | §5 output top-level 에 추가 (sub_results 있으면 필수) |
+
+회귀 자체에는 영향 없음 (enum 동일하므로), 다만 spec doc 에 명시 추가.
+
+## 9. v0.5.0 → v0.5.7 변경 통계
+
+```
+v0.5.0 (PR #13): 42/42 smoke + MiniMax Code harness overlay
+v0.5.1 (PR #14): per-harness MCP install + auto-emit + guide
+v0.5.1 (PR #15): check_bootstrap_mcp_roundtrip + 5 harnesses round-trip
+v0.5.2 (PR #16): bootstrap 풀 리팩터 + 패키지화 + pilot validation
+v0.5.3 (PR #17): antigravity MCP 표준화 + cross-language stack 표시
+v0.5.4 (PR #18): orchestrator ↔ sub-agent contract v1 + maturity sync + baseline sync
+v0.5.5 (PR #19): Phase 11 본격 pilot (Devhub Example × Contract v1)
+v0.5.6 (PR #20): contract v1 §5/§6 P0 enforcement (validator + delegator)
+v0.5.7 (PR #21): contract v1 §4.2/§5.2 multi-component fan-out/in + §6.3 cross-ref row
+```
+
+총 9 PR.
+
+## 10. 다음 단계 (v0.5.8 후보)
+
+- [ ] Mavis 측 `choose_role`/`choose_roles` 을 mavis-team engine 의 `delegate_to_subagent` hook 에 자동 wire (가이드 v0.5.7 기반)
+- [ ] PyPI 배포 (v0.5.2 부터 보류 중)
+- [ ] Phase 11 case study 추가 — v0.5.7 fan-out/in 시나리오 walkthrough (Devhub N+1 endpoint 4 동시 처리)
+- [ ] contract v2 스트리밍 출력 / 양방향 ping / observability (v0.5.7 §11 1차 컷 외 항목)
+- [ ] `task.required_model_tier` 의 keyword 사전 외부화 (config 기반)
+
+## 11. 메모리 layer
+
+v0.5.7 의 모든 작업은 `ai-workflow/memory/release/v0.5.7/` 에 기록:
+- `PROJECT_PROFILE.md` — v0.5.7 프로젝트 프로파일 (choose_roles/validate_fanin/recommend_model_tier/wire_guide 추가)
+- `session_handoff.md` — 세션 인계
+- `backlog/2026-06-08.md` — TASK 상세
+- `state.json` — workflow 상태 캐시
+
+## 12. 이슈 트래커
+
+- ✅ [issue #1](https://github.com/ykylee/standard_ai_workflow/issues/1) 영구 해결 (v0.5.4)
+- 0 open issues

--- a/workflow-source/tests/check_contract_v1_delegator.py
+++ b/workflow-source/tests/check_contract_v1_delegator.py
@@ -3,9 +3,10 @@
 
 Verifies that workflow_kit.contract_v1.delegator.choose_role correctly:
 - maps the 4 task_types to roles per §6.1
-- rejects all 7 §6.3 MUST-NOT-delegate markers (handoff / backlog / state.json / ask_user / 우선순위 / 통합/리뷰 / PR 본문)
+- rejects all 9 §6.3 MUST-NOT-delegate markers (v0.5.6: 7 + v0.5.7: cross-ref / fan-in 통합)
 - raises on unknown task_type
 - generates valid §4 delegation_id format
+- (v0.5.7) recommends model_tier based on task keywords
 
 Reference: workflow-source/core/orchestrator_subagent_contract_v1.md §6
 """
@@ -19,7 +20,11 @@ from pathlib import Path
 SOURCE_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SOURCE_ROOT))
 
-from workflow_kit.contract_v1 import choose_role, DelegationRejected  # noqa: E402
+from workflow_kit.contract_v1 import (  # noqa: E402
+    choose_role,
+    DelegationRejected,
+    recommend_model_tier,
+)
 
 DELEGATION_ID_RE = re.compile(r"^del-\d{4}-\d{2}-\d{2}-[0-9a-f]{8}$")
 
@@ -55,7 +60,11 @@ def check_task_type_to_role_mapping() -> None:
 
 
 def check_must_not_delegate_rejection() -> None:
-    """§6.3: all 7 markers must be rejected with must_not_delegate=True."""
+    """§6.3: all 9 markers must be rejected with must_not_delegate=True.
+
+    v0.5.6: 7 markers (handoff, backlog, state.json, ask_user, 우선순위, 통합/리뷰, PR 본문)
+    v0.5.7: +2 (cross-ref, fan-in 통합)
+    """
     cases = [
         ("handoff 갱신 및 정리", "handoff 갱신은 orchestrator 직접 처리 (contract v1 §6.3)"),
         ("backlog update", "backlog 갱신은 orchestrator 직접 처리 (contract v1 §6.3)"),
@@ -64,6 +73,15 @@ def check_must_not_delegate_rejection() -> None:
         ("우선순위 결정", "우선순위 결정은 orchestrator 직접 처리 (contract v1 §6.3)"),
         ("sub-agent 출력 통합/리뷰", "sub-agent 출력 통합/리뷰는 orchestrator 직접 처리 (contract v1 §6.3)"),
         ("PR 본문 작성", "PR 본문 작성은 orchestrator 직접 처리 (contract v1 §6.3)"),
+        # v0.5.7 신규
+        (
+            "docs cross-ref 갱신 (3 doc-link + 2 memory link)",
+            "cross-ref 갱신은 orchestrator 직접 처리 (contract v1 §6.3, v0.5.7)",
+        ),
+        (
+            "fan-in 통합 보고서 작성",
+            "fan-in 통합 보고는 orchestrator 직접 처리 (contract v1 §6.3, v0.5.7)",
+        ),
     ]
     for brief, expected_reason in cases:
         decision = choose_role(_task("doc_draft", brief=brief))
@@ -126,6 +144,66 @@ def check_non_must_not_delegate_brief_passes() -> None:
         )
 
 
+def check_recommend_model_tier_main_keywords() -> None:
+    """v0.5.7: model_tier 자동 결정 — main 후보 keyword 매치 시 'main'."""
+    main_cases = [
+        {"brief": "아키텍처 재설계 — 모듈 경계 변경", "task_type": "code_change"},
+        {"brief": "정책 문구 추가 (보안 정책 v2)", "task_type": "doc_draft"},
+        {"brief": "5+ 파일 cross-cutting refactor", "task_type": "code_change"},
+        {"brief": "bounded_research 5+ source 종합", "task_type": "bounded_research"},
+    ]
+    for task in main_cases:
+        tier = recommend_model_tier(task)
+        if tier != "main":
+            raise AssertionError(
+                f"task brief={task['brief']!r} should recommend 'main', got {tier!r}"
+            )
+
+
+def check_recommend_model_tier_default_small() -> None:
+    """v0.5.7: main keyword 가 없으면 'small'."""
+    small_cases = [
+        {"brief": "단일 파일 200줄 read", "task_type": "doc_draft"},
+        {"brief": "build / lint / test 실행", "task_type": "validation_run"},
+        {"brief": "small fix 1 file", "task_type": "code_change"},
+    ]
+    for task in small_cases:
+        tier = recommend_model_tier(task)
+        if tier != "small":
+            raise AssertionError(
+                f"task brief={task['brief']!r} should recommend 'small', got {tier!r}"
+            )
+
+
+def check_recommend_model_tier_explicit_override() -> None:
+    """v0.5.7: required_model_tier 명시 시 override."""
+    # 명시적으로 small 인데 brief 가 main keyword 있어도 small
+    tier = recommend_model_tier({
+        "brief": "아키텍처 재설계",
+        "task_type": "code_change",
+        "required_model_tier": "small",
+    })
+    if tier != "small":
+        raise AssertionError(f"explicit small should override brief keyword, got {tier!r}")
+    # 명시적으로 main 인데 brief 가 일반이어도 main
+    tier = recommend_model_tier({
+        "brief": "small fix",
+        "task_type": "code_change",
+        "required_model_tier": "main",
+    })
+    if tier != "main":
+        raise AssertionError(f"explicit main should override default, got {tier!r}")
+
+
+def check_choose_role_returns_recommended_tier() -> None:
+    """v0.5.7: choose_role 결과에 recommended_model_tier 박혀 있어야."""
+    decision = choose_role(_task("code_change", brief="아키텍처 변경"))
+    if decision.recommended_model_tier != "main":
+        raise AssertionError(
+            f"choose_role should propagate recommended_model_tier=main, got {decision.recommended_model_tier!r}"
+        )
+
+
 def main() -> int:
     check_task_type_to_role_mapping()
     check_must_not_delegate_rejection()
@@ -133,10 +211,17 @@ def main() -> int:
     check_unknown_task_type_raises()
     check_marker_in_primary_artifact_also_rejected()
     check_non_must_not_delegate_brief_passes()
+    # v0.5.7 신규
+    check_recommend_model_tier_main_keywords()
+    check_recommend_model_tier_default_small()
+    check_recommend_model_tier_explicit_override()
+    check_choose_role_returns_recommended_tier()
     print(
         "Contract v1 §6.1/§6.3 delegator smoke check passed "
-        "(4 task_type mappings, 7 must-not-delegate rejections, strict mode, "
-        "unknown type, primary_artifact marker, non-match baseline)."
+        "(4 task_type mappings, 9 must-not-delegate rejections [7 v0.5.6 + 2 v0.5.7], "
+        "strict mode, unknown type, primary_artifact marker, non-match baseline, "
+        "model_tier main keywords, model_tier default small, model_tier explicit "
+        "override, choose_role propagates tier)."
     )
     return 0
 

--- a/workflow-source/tests/check_contract_v1_direct_only.py
+++ b/workflow-source/tests/check_contract_v1_direct_only.py
@@ -13,6 +13,7 @@ from pathlib import Path
 CONTRACT_PATH = Path(__file__).resolve().parents[1] / "core" / "orchestrator_subagent_contract_v1.md"
 
 # §6.3 MUST NOT delegate list (negative test catalog).
+# v0.5.6: 7 actions. v0.5.7: +2 (cross-ref 갱신, fan-in 통합 보고).
 DIRECT_ONLY_ACTIONS = (
     "handoff 갱신",
     "backlog 갱신",
@@ -21,6 +22,9 @@ DIRECT_ONLY_ACTIONS = (
     "우선순위 결정",
     "sub-agent 출력 통합/리뷰",
     "PR 본문 작성",
+    # v0.5.7 신규
+    "docs cross-ref 갱신",
+    "fan-in 통합 보고",
 )
 
 
@@ -70,7 +74,7 @@ def main() -> int:
     _check_doc_has_section_6_3()
     check_direct_only_actions_rejected()
     check_negative_test_examples_present()
-    print("Contract v1 direct-only smoke check passed (7 MUST-NOT-delegate actions + §8.3 negative examples).")
+    print("Contract v1 direct-only smoke check passed (9 MUST-NOT-delegate actions [7 v0.5.6 + 2 v0.5.7] + §8.3 negative examples).")
     return 0
 
 

--- a/workflow-source/tests/check_contract_v1_multi_component.py
+++ b/workflow-source/tests/check_contract_v1_multi_component.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Contract v1 §4.2 / §5.2 multi-component fan-out / fan-in regression check.
+
+Verifies that workflow_kit.contract_v1 (v0.5.7) correctly handles:
+- delegator.choose_roles: batch delegation for `task.sub_tasks` (fan-out)
+  - parent decision first, then per-sub decision with `sub_id` + parent-prefix delegation_id
+  - schema validation for sub_tasks
+  - §6.3 rejection in any sub propagates correctly
+- output_validator.validate_fanin_output: fan-in payload validation
+  - sub_results required fields + delegation_id prefix match
+  - aggregated status consistency (any failed→failed, any partial→partial, else ok)
+  - parent_delegation_id field
+- baseline: 1 parent + 3 sub fan-out/in pilot walkthrough passes
+- violation: parent §6.3 violation propagates, sub schema invalid raises
+
+Reference: workflow-source/core/orchestrator_subagent_contract_v1.md §4.2, §5.2
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SOURCE_ROOT))
+
+from workflow_kit.contract_v1 import (  # noqa: E402
+    choose_roles,
+    DelegationRejected,
+    validate_fanin_output,
+)
+
+
+def _ok_payload(
+    delegation_id: str = "del-2026-06-08-fanin-pilot",
+    parent_id: str = "del-2026-06-08-fanout-pilot",
+    sub_statuses: list[str] | None = None,
+) -> dict[str, object]:
+    """Build a valid §5.2 fan-in payload for testing."""
+    if sub_statuses is None:
+        sub_statuses = ["ok", "ok", "ok"]
+    sub_results: list[dict[str, object]] = []
+    for i, st in enumerate(sub_statuses, start=1):
+        sub_results.append({
+            "sub_id": f"st-{i}",
+            "delegation_id": f"{parent_id}-st-{i}",
+            "status": st,
+            "summary": f"sub {i} done",
+            "written_paths": [f"file_{i}.py"],
+        })
+    # aggregated status
+    if any(s == "failed" for s in sub_statuses):
+        agg = "failed"
+    elif any(s == "partial" for s in sub_statuses):
+        agg = "partial"
+    else:
+        agg = "ok"
+    return {
+        "contract_version": "1.0",
+        "delegation_id": delegation_id,
+        "completed_at": "2026-06-08T17:30:00+09:00",
+        "parent_delegation_id": parent_id,
+        "worker": {
+            "session_id": "mvs_parent_test",
+            "role": "code-worker",
+            "model_tier": "main",
+        },
+        "result": {
+            "status": agg,
+            "summary": f"{len(sub_statuses)} sub-component 처리, aggregated={agg}",
+            "artifacts": [
+                {"path": "backend-core/handlers/auth_logout.go", "kind": "code", "action": "created", "added": 1, "removed": 0, "total": 1},
+                {"path": "backend-core/handlers/ci_runs.go", "kind": "code", "action": "modified", "added": 5, "removed": 1, "total": 42},
+            ],
+            "written_paths": ["backend-core/handlers/auth_logout.go", "backend-core/handlers/ci_runs.go"],
+            "sub_results": sub_results,
+            "validation_result": {"ran": True, "status": "pass", "details": "all sub ok"},
+            "next_step": "orchestrator 가 PR 본문 작성 + cross-link 갱신",
+        },
+    }
+
+
+def _fanout_task() -> dict[str, object]:
+    """A 3-sub fan-out task mirroring the v0.5.7 spec example.
+
+    sub_tasks 의 parent_delegation_id 는 비워둠 — choose_roles 이 자동 채움
+    (delegator 가 §4.2 parent delegation_id 발급 권한 = orchestrator).
+    """
+    return {
+        "task_type": "code_change",
+        "brief": "Devhub N+1 endpoint 1차 구현 + 4 시나리오 동시 진행",
+        "expected_outputs": {
+            "primary_artifact": "backend-core/handlers/",
+            "artifact_kind": "code",
+            "must_include": ["3 sub-component 모두 PASS", "fan-in aggregation 1 report"],
+        },
+        "sub_tasks": [
+            {
+                "sub_id": "st-1",
+                "task_type": "code_change",
+                "brief": "POST /auth/logout 구현 (OIDC + 204)",
+                "primary_artifact": "backend-core/handlers/auth_logout.go",
+                "artifact_kind": "code",
+            },
+            {
+                "sub_id": "st-2",
+                "task_type": "code_change",
+                "brief": "POST /ci-runs 구현 (repository_id + 7 enum + 409 idempotency)",
+                "primary_artifact": "backend-core/handlers/ci_runs.go",
+                "artifact_kind": "code",
+            },
+            {
+                "sub_id": "st-3",
+                "task_type": "validation_run",
+                "brief": "4 endpoint 통합 test suite 실행",
+                "primary_artifact": "backend-core/tests/contract_v1_integration.py",
+                "artifact_kind": "code",
+            },
+        ],
+    }
+
+
+def check_choose_roles_single_no_subtasks() -> None:
+    """sub_tasks 없으면 단일 결과 (backward compatible)."""
+    task = {
+        "task_type": "doc_draft",
+        "brief": "draft spec",
+        "expected_outputs": {"primary_artifact": "spec.md"},
+    }
+    decisions = choose_roles(task)
+    if len(decisions) != 1:
+        raise AssertionError(f"single task should yield 1 decision, got {len(decisions)}")
+    if decisions[0].role != "doc-worker":
+        raise AssertionError(f"role mismatch: {decisions[0].role!r}")
+    if decisions[0].sub_id is not None:
+        raise AssertionError(f"single task should have sub_id=None, got {decisions[0].sub_id!r}")
+
+
+def check_choose_roles_fanout_three_subs() -> None:
+    """3 sub-task fan-out: parent + 3 sub decisions."""
+    task = _fanout_task()
+    decisions = choose_roles(task)
+    if len(decisions) != 4:
+        raise AssertionError(f"3-sub fan-out should yield 4 decisions (parent + 3), got {len(decisions)}")
+    parent = decisions[0]
+    if parent.role != "code-worker":
+        raise AssertionError(f"parent role should be code-worker, got {parent.role!r}")
+    if parent.delegation_id is None:
+        raise AssertionError("parent delegation_id should be set")
+    # sub decisions
+    expected_sub_roles = ["code-worker", "code-worker", "validation-worker"]
+    for i, sub_decision in enumerate(decisions[1:], start=0):
+        if sub_decision.role != expected_sub_roles[i]:
+            raise AssertionError(
+                f"sub {i} role should be {expected_sub_roles[i]!r}, got {sub_decision.role!r}"
+            )
+        if sub_decision.sub_id != f"st-{i + 1}":
+            raise AssertionError(
+                f"sub {i} sub_id should be st-{i + 1}, got {sub_decision.sub_id!r}"
+            )
+        if sub_decision.delegation_id is None:
+            raise AssertionError(f"sub {i} delegation_id should be set")
+        if f"st-{i + 1}" not in sub_decision.delegation_id:
+            raise AssertionError(
+                f"sub {i} delegation_id {sub_decision.delegation_id!r} should contain sub_id st-{i + 1}"
+            )
+        # 서브 delegation_id 들이 서로 유니크
+        sibling_ids = [d.delegation_id for d in decisions[1:] if d.delegation_id is not None]
+        if len(sibling_ids) != len(set(sibling_ids)):
+            raise AssertionError(
+                f"sub delegation_ids should be unique within parent fan-out, got {sibling_ids}"
+            )
+
+
+def check_choose_roles_parent_must_not_delegate_propagates() -> None:
+    """parent brief 가 §6.3 위반이면 fan-out 전체 거부 (non-strict)."""
+    task = _fanout_task()
+    task["brief"] = "handoff 갱신 + 3 sub fan-out"  # §6.3 marker
+    decisions = choose_roles(task, strict=False)
+    if not decisions[0].must_not_delegate:
+        raise AssertionError("parent with §6.3 marker should be must_not_delegate=True")
+    if decisions[0].rejected_reason is None or "handoff" not in decisions[0].rejected_reason:
+        raise AssertionError(
+            f"rejected_reason should mention handoff, got {decisions[0].rejected_reason!r}"
+        )
+
+
+def check_choose_roles_parent_must_not_delegate_strict_raises() -> None:
+    """parent §6.3 위반 + strict=True 면 DelegationRejected raise."""
+    task = _fanout_task()
+    task["brief"] = "PR 본문 작성 + 3 sub"
+    try:
+        choose_roles(task, strict=True)
+    except DelegationRejected as exc:
+        if not exc.decision.must_not_delegate:
+            raise AssertionError("DelegationRejected but must_not_delegate=False")
+        return
+    raise AssertionError("strict=True on parent §6.3 should raise DelegationRejected")
+
+
+def check_choose_roles_sub_must_not_delegate_propagates() -> None:
+    """sub brief 가 §6.3 위반이면 §6.3 marker 가 haystack 에 들어가
+    parent 부터 reject 됨 (delegator 가 sub brief 까지 검사, v0.5.7 spec §6.3).
+    """
+    task = _fanout_task()
+    task["sub_tasks"][1]["brief"] = "backlog update 처리"  # st-2 위반
+    decisions = choose_roles(task, strict=False)
+    # v0.5.7 spec: sub 의 §6.3 marker 도 parent fan-out 전체 거부 (정합성)
+    # orchestrator 가 sub brief 까지 보고 fan-out 결정을 내리는 것이 안전
+    if not decisions[0].must_not_delegate:
+        raise AssertionError(
+            "v0.5.7 spec §6.3: sub brief 의 marker 도 parent reject 야 함 "
+            "(sub 가 fan-out 의 일부이므로)"
+        )
+    if decisions[0].rejected_reason is None or "backlog" not in decisions[0].rejected_reason:
+        raise AssertionError(
+            f"rejected_reason should mention backlog, got {decisions[0].rejected_reason!r}"
+        )
+
+
+def check_choose_roles_sub_schema_invalid_raises() -> None:
+    """sub_task schema 가 잘못되면 ValueError."""
+    task = _fanout_task()
+    task["sub_tasks"][0] = {"sub_id": "st-1"}  # 필수 필드 누락
+    try:
+        choose_roles(task)
+    except ValueError as exc:
+        if "missing required field" not in str(exc):
+            raise AssertionError(f"ValueError should mention 'missing required field', got: {exc}")
+        return
+    raise AssertionError("sub_task with missing fields should raise ValueError")
+
+
+def check_choose_roles_sub_task_type_invalid_raises() -> None:
+    """sub_task 의 task_type 이 enum 밖이면 ValueError."""
+    task = _fanout_task()
+    task["sub_tasks"][0]["task_type"] = "magic_type"  # 알 수 없음
+    try:
+        choose_roles(task)
+    except ValueError as exc:
+        if "task_type" not in str(exc):
+            raise AssertionError(f"ValueError should mention 'task_type', got: {exc}")
+        return
+    raise AssertionError("invalid sub_task_type should raise ValueError")
+
+
+def check_validate_fanin_ok() -> None:
+    """baseline: ok sub_results → validate PASS."""
+    payload = _ok_payload()
+    result = validate_fanin_output(payload, expected_parent_delegation_id="del-2026-06-08-fanout-pilot")
+    if not result.is_valid:
+        raise AssertionError(f"baseline ok should validate, errors: {result.errors}")
+
+
+def check_validate_fanin_partial_aggregation() -> None:
+    """partial sub 1개 → aggregated status 'partial'."""
+    payload = _ok_payload(sub_statuses=["ok", "partial", "ok"])
+    result = validate_fanin_output(payload, expected_parent_delegation_id="del-2026-06-08-fanout-pilot")
+    if not result.is_valid:
+        raise AssertionError(f"partial aggregation should validate, errors: {result.errors}")
+
+
+def check_validate_fanin_failed_aggregation() -> None:
+    """failed sub 1개 → aggregated status 'failed'."""
+    payload = _ok_payload(sub_statuses=["ok", "failed", "ok"])
+    result = validate_fanin_output(payload, expected_parent_delegation_id="del-2026-06-08-fanout-pilot")
+    if not result.is_valid:
+        raise AssertionError(f"failed aggregation should validate, errors: {result.errors}")
+
+
+def check_validate_fanin_status_mismatch() -> None:
+    """declared status 가 aggregated 와 불일치 → error."""
+    payload = _ok_payload(sub_statuses=["ok", "failed", "ok"])
+    payload["result"]["status"] = "ok"  # 잘못된 declared status
+    result = validate_fanin_output(payload, expected_parent_delegation_id="del-2026-06-08-fanout-pilot")
+    if result.is_valid:
+        raise AssertionError("status mismatch should produce error")
+    if not any("declared" in e.reason and "aggregate" in e.reason for e in result.errors):
+        raise AssertionError(f"expected aggregation mismatch error, got: {result.errors}")
+
+
+def check_validate_fanin_parent_mismatch() -> None:
+    """expected_parent_delegation_id 와 parent_delegation_id 불일치 → error."""
+    payload = _ok_payload()
+    result = validate_fanin_output(payload, expected_parent_delegation_id="del-WRONG")
+    if result.is_valid:
+        raise AssertionError("parent mismatch should produce error")
+    if not any(e.field == "parent_delegation_id" for e in result.errors):
+        raise AssertionError(f"expected parent_delegation_id error, got: {result.errors}")
+
+
+def check_validate_fanin_sub_delegation_id_prefix_mismatch() -> None:
+    """sub_result delegation_id 가 parent prefix 와 불일치 → error."""
+    payload = _ok_payload()
+    payload["result"]["sub_results"][0]["delegation_id"] = "del-WRONG-st-1"
+    result = validate_fanin_output(payload, expected_parent_delegation_id="del-2026-06-08-fanout-pilot")
+    if result.is_valid:
+        raise AssertionError("sub delegation_id prefix mismatch should produce error")
+
+
+def check_validate_fanin_missing_sub_field() -> None:
+    """sub_result 필수 필드 누락 → error."""
+    payload = _ok_payload()
+    del payload["result"]["sub_results"][0]["summary"]
+    result = validate_fanin_output(payload, expected_parent_delegation_id="del-2026-06-08-fanout-pilot")
+    if result.is_valid:
+        raise AssertionError("missing sub_result field should produce error")
+
+
+def check_validate_fanin_missing_parent_field() -> None:
+    """sub_results 가 있는데 parent_delegation_id 없으면 error."""
+    payload = _ok_payload()
+    del payload["parent_delegation_id"]
+    result = validate_fanin_output(payload, expected_parent_delegation_id="del-2026-06-08-fanout-pilot")
+    if result.is_valid:
+        raise AssertionError("missing parent_delegation_id with sub_results should produce error")
+
+
+def check_validate_fanin_artifact_action_and_stats() -> None:
+    """artifacts[].action + added/removed/total 검증 (§5 + v0.5.7 P2)."""
+    payload = _ok_payload()
+    result = validate_fanin_output(payload)
+    if not result.is_valid:
+        raise AssertionError(f"baseline with action/stats should validate, errors: {result.errors}")
+
+
+def check_validate_fanin_invalid_action() -> None:
+    """artifacts[].action 이 enum 밖이면 error."""
+    payload = _ok_payload()
+    payload["result"]["artifacts"][0]["action"] = "magic"
+    result = validate_fanin_output(payload)
+    if result.is_valid:
+        raise AssertionError("invalid action enum should produce error")
+
+
+def check_validate_fanin_invalid_stat_type() -> None:
+    """artifacts[].added 가 int 아니면 error."""
+    payload = _ok_payload()
+    payload["result"]["artifacts"][0]["added"] = "three"  # str
+    result = validate_fanin_output(payload)
+    if result.is_valid:
+        raise AssertionError("non-int added should produce error")
+
+
+def main() -> int:
+    # choose_roles
+    check_choose_roles_single_no_subtasks()
+    check_choose_roles_fanout_three_subs()
+    check_choose_roles_parent_must_not_delegate_propagates()
+    check_choose_roles_parent_must_not_delegate_strict_raises()
+    check_choose_roles_sub_must_not_delegate_propagates()
+    check_choose_roles_sub_schema_invalid_raises()
+    check_choose_roles_sub_task_type_invalid_raises()
+    # validate_fanin_output
+    check_validate_fanin_ok()
+    check_validate_fanin_partial_aggregation()
+    check_validate_fanin_failed_aggregation()
+    check_validate_fanin_status_mismatch()
+    check_validate_fanin_parent_mismatch()
+    check_validate_fanin_sub_delegation_id_prefix_mismatch()
+    check_validate_fanin_missing_sub_field()
+    check_validate_fanin_missing_parent_field()
+    check_validate_fanin_artifact_action_and_stats()
+    check_validate_fanin_invalid_action()
+    check_validate_fanin_invalid_stat_type()
+    print(
+        "Contract v1 §4.2/§5.2 multi-component smoke check passed "
+        "(choose_roles: single/3-sub/parent-reject/strict/sub-reject/schema-invalid/type-invalid; "
+        "validate_fanin_output: ok/partial/failed aggregation, status mismatch, parent mismatch, "
+        "sub delegation_id prefix mismatch, missing sub field, missing parent, "
+        "artifact action+stats, invalid action, invalid stat type)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflow-source/workflow_kit/contract_v1/__init__.py
+++ b/workflow-source/workflow_kit/contract_v1/__init__.py
@@ -4,6 +4,11 @@ Two enforcement helpers introduced in v0.5.6 (P0 from v0.5.5 pilot findings):
 - `output_validator`: validates a sub-agent output payload against §5 of the contract.
 - `delegator.choose_role`: decides role mapping per §6.1 + rejects §6.3 actions.
 
+v0.5.7 extends with multi-component fan-out/in (P1 from v0.5.5 pilot):
+- `output_validator.validate_fanin_output`: validates fan-in payload + sub_results
+- `delegator.choose_roles`: batch delegation decisions for `task.sub_tasks`
+- `delegator.recommend_model_tier`: auto small/main decision per keyword rules
+
 Both modules are pure Python (no external deps beyond the standard library) so
 they can be imported from any orchestrator runtime (Mavis, mavis, OpenCode,
 Gemini CLI, etc.) and from sub-agent runtimes that already depend on the
@@ -16,18 +21,24 @@ from .output_validator import (
     OutputValidationError,
     OutputValidationResult,
     validate_output,
+    validate_fanin_output,
 )
 from .delegator import (
     DelegationDecision,
     DelegationRejected,
     choose_role,
+    choose_roles,
+    recommend_model_tier,
 )
 
 __all__ = [
     "OutputValidationError",
     "OutputValidationResult",
     "validate_output",
+    "validate_fanin_output",
     "DelegationDecision",
     "DelegationRejected",
     "choose_role",
+    "choose_roles",
+    "recommend_model_tier",
 ]

--- a/workflow-source/workflow_kit/contract_v1/delegator.py
+++ b/workflow-source/workflow_kit/contract_v1/delegator.py
@@ -1,8 +1,11 @@
-"""§6.1 / §6.3 Delegator for Orchestrator ↔ Sub-agent Contract v1.
+"""§6.1 / §6.3 / §6.5 Delegator for Orchestrator ↔ Sub-agent Contract v1.
 
-Decides role mapping per §6.1 (MUST delegate) and rejects §6.3 (MUST NOT
-delegate) actions. Used by the orchestrator side to auto-enforce the contract
-on every task it considers doing itself (P0 from v0.5.5 pilot findings).
+Decides role mapping per §6.1 (MUST delegate), rejects §6.3 (MUST NOT
+delegate) actions, and (v0.5.7) supports multi-component fan-out via
+`choose_roles` and model_tier recommendation via `recommend_model_tier`.
+
+Used by the orchestrator side to auto-enforce the contract on every task it
+considers doing itself (P0 from v0.5.5 pilot findings).
 
 Reference: workflow-source/core/orchestrator_subagent_contract_v1.md §6
 """
@@ -15,6 +18,8 @@ from typing import Any
 
 # §3.1~§3.5 role names (must match contract v1 spec)
 ALLOWED_ROLES = ("doc-worker", "code-worker", "validation-worker", "workflow-worker")
+# §3 model_tier enum
+ALLOWED_MODEL_TIERS = ("small", "main")
 # §4 task_type enum
 ALLOWED_TASK_TYPES = ("doc_draft", "code_change", "validation_run", "bounded_research")
 
@@ -26,7 +31,7 @@ TASK_TYPE_TO_ROLE: dict[str, str] = {
     "bounded_research": "doc-worker",
 }
 
-# §6.3 MUST-NOT-delegate actions (7 explicit per the spec).
+# §6.3 MUST-NOT-delegate actions (7 in v0.5.6, +2 in v0.5.7 → 9 total).
 # Substring match against `task.brief` and `task.expected_outputs.primary_artifact`.
 # Each entry is (marker, human-readable reason).
 MUST_NOT_DELEGATE_MARKERS: tuple[tuple[str, str], ...] = (
@@ -37,6 +42,27 @@ MUST_NOT_DELEGATE_MARKERS: tuple[tuple[str, str], ...] = (
     ("우선순위", "우선순위 결정은 orchestrator 직접 처리 (contract v1 §6.3)"),
     ("통합/리뷰", "sub-agent 출력 통합/리뷰는 orchestrator 직접 처리 (contract v1 §6.3)"),
     ("PR 본문", "PR 본문 작성은 orchestrator 직접 처리 (contract v1 §6.3)"),
+    # v0.5.7 신규: cross-ref 갱신은 orchestrator 의 단일 진실 공급원 책임
+    (
+        "cross-ref",
+        "cross-ref 갱신은 orchestrator 직접 처리 (contract v1 §6.3, v0.5.7)",
+    ),
+    # v0.5.7 신규: fan-in 통합 보고 작성을 sub-agent 가 시도하는 것도 거부
+    (
+        "fan-in 통합",
+        "fan-in 통합 보고는 orchestrator 직접 처리 (contract v1 §6.3, v0.5.7)",
+    ),
+)
+
+# v0.5.7: model_tier main 승격 keyword (case-insensitive substring match
+# against task.brief, task.constraints, task.must_include).
+# If any keyword matches, delegator.recommend_model_tier returns "main".
+MAIN_TIER_KEYWORDS: tuple[str, ...] = (
+    "아키텍처",
+    "정책",
+    "5+ 파일",
+    "cross-cutting",
+    "5+ source",
 )
 
 
@@ -54,6 +80,8 @@ class DelegationDecision:
     warnings: list[str] = field(default_factory=list)
     delegation_id: str | None = None
     task_type: str | None = None
+    recommended_model_tier: str | None = None  # v0.5.7
+    sub_id: str | None = None  # v0.5.7: fan-out sub-task id
 
 
 class DelegationRejected(ValueError):
@@ -65,12 +93,28 @@ class DelegationRejected(ValueError):
 
 
 def _generate_delegation_id() -> str:
-    """Generate a unique delegation_id per the §4 format `del-YYYY-MM-DD-NNN`."""
-    # We keep a date prefix for human readability; the suffix is a short uuid4 hex.
+    """Generate a unique delegation_id per the §4 format `del-YYYY-MM-DD-NNN`.
+
+    Default 8-char uuid4 hex suffix; callers may append their own suffix via
+    `_generate_delegation_id_with_suffix` for sub-task fan-out.
+    """
     from datetime import date
     today = date.today().isoformat()
     suffix = uuid.uuid4().hex[:8]
     return f"del-{today}-{suffix}"
+
+
+def _generate_delegation_id_with_suffix(extra: str) -> str:
+    """Generate `del-YYYY-MM-DD-<base>-<extra>` for sub-task fan-out (v0.5.7).
+
+    `extra` 는 sub_id 그대로 (e.g. "st-1") 가 들어옴. sub 가 fan-out parent
+    session 내에서 유니크하도록 base uuid4 hex 6자 + sub_id 결합.
+    """
+    from datetime import date
+    today = date.today().isoformat()
+    base = uuid.uuid4().hex[:6]
+    safe_extra = "".join(c for c in extra if c.isalnum() or c in "-_")[:24]
+    return f"del-{today}-{base}-{safe_extra}"
 
 
 def _looks_like_must_not_delegate(task: dict[str, Any]) -> tuple[bool, str | None]:
@@ -79,6 +123,8 @@ def _looks_like_must_not_delegate(task: dict[str, Any]) -> tuple[bool, str | Non
     Returns (matched, reason). The marker is substring-matched; matches are
     case-insensitive. We intentionally do NOT match "handoff" inside e.g.
     "handoff_path" — only the bare marker word to reduce false positives.
+
+    v0.5.7: also inspects sub_tasks[].brief when present.
     """
     brief = str(task.get("brief", ""))
     primary = str(
@@ -87,18 +133,92 @@ def _looks_like_must_not_delegate(task: dict[str, Any]) -> tuple[bool, str | Non
         else ""
     )
     haystack = f"{brief}\n{primary}".lower()
+    # v0.5.7: also scan sub_tasks brief
+    for sub in task.get("sub_tasks", []) or []:
+        if isinstance(sub, dict):
+            haystack += "\n" + str(sub.get("brief", "")).lower()
     for marker, reason in MUST_NOT_DELEGATE_MARKERS:
         if marker.lower() in haystack:
             return True, reason
     return False, None
 
 
+def _validate_sub_task(sub: Any, parent_delegation_id: str | None) -> None:
+    """Validate a sub-task dict per §4.2 (v0.5.7).
+
+    Raises ValueError on schema violation. When `parent_delegation_id` is
+    provided AND `sub.parent_delegation_id` is set, they must match. If
+    `sub.parent_delegation_id` is missing, the caller (choose_roles) will
+    auto-fill it.
+    """
+    if not isinstance(sub, dict):
+        raise ValueError(f"sub_task must be a dict, got {type(sub).__name__}")
+    for field_name in ("sub_id", "task_type", "brief", "primary_artifact", "artifact_kind"):
+        if field_name not in sub:
+            raise ValueError(f"sub_task missing required field: {field_name}")
+    if sub["task_type"] not in ALLOWED_TASK_TYPES:
+        raise ValueError(
+            f"sub_task.task_type must be one of {ALLOWED_TASK_TYPES}, "
+            f"got {sub['task_type']!r}"
+        )
+    if sub["artifact_kind"] not in (
+        "markdown", "python", "json", "toml", "text", "code", "other",
+    ):
+        raise ValueError(
+            f"sub_task.artifact_kind invalid: {sub['artifact_kind']!r}"
+        )
+    if parent_delegation_id is not None and sub.get("parent_delegation_id") is not None:
+        if sub["parent_delegation_id"] != parent_delegation_id:
+            raise ValueError(
+                f"sub_task.parent_delegation_id={sub.get('parent_delegation_id')!r} "
+                f"does not match parent delegation_id={parent_delegation_id!r}"
+            )
+
+
+def recommend_model_tier(task: dict[str, Any]) -> str:
+    """v0.5.7: 자동 model_tier 결정.
+
+    Returns "main" if the task brief/constraints/must_include matches any
+    main-tier keyword (architecture, policy, 5+ file cross-cutting, etc.).
+    Otherwise returns "small".
+
+    Respects explicit `task.required_model_tier` if set ("small" or "main").
+
+    Args:
+        task: A task dict matching contract v1 §4. Inspects `brief`,
+            `constraints`, `expected_outputs.must_include`, and
+            `required_model_tier`.
+
+    Returns:
+        "small" or "main".
+    """
+    explicit = task.get("required_model_tier")
+    if explicit in ALLOWED_MODEL_TIERS:
+        return explicit
+    haystack_parts: list[str] = []
+    haystack_parts.append(str(task.get("brief", "")))
+    for c in task.get("constraints", []) or []:
+        if isinstance(c, str):
+            haystack_parts.append(c)
+    expected = task.get("expected_outputs", {})
+    if isinstance(expected, dict):
+        for item in expected.get("must_include", []) or []:
+            if isinstance(item, str):
+                haystack_parts.append(item)
+    haystack = "\n".join(haystack_parts).lower()
+    for kw in MAIN_TIER_KEYWORDS:
+        if kw.lower() in haystack:
+            return "main"
+    return "small"
+
+
 def choose_role(task: dict[str, Any], *, strict: bool = False) -> DelegationDecision:
     """Decide which role a task should be delegated to, per contract v1 §6.
 
     Args:
-        task: A task dict matching contract v1 §4 input schema. Only `task_type`,
-            `brief`, and `expected_outputs.primary_artifact` are inspected.
+        task: A task dict matching contract v1 §4 input schema. Inspects
+            `task_type`, `brief`, `expected_outputs.primary_artifact`,
+            `sub_tasks` (v0.5.7), and `required_model_tier` (v0.5.7).
         strict: If True, raise DelegationRejected on §6.3 violation instead
             of returning a `must_not_delegate=True` decision. Default False
             (the orchestrator's normal-mode "warn, do not delegate" path).
@@ -110,7 +230,8 @@ def choose_role(task: dict[str, Any], *, strict: bool = False) -> DelegationDeci
 
     Raises:
         DelegationRejected: only if `strict=True` and §6.3 is violated.
-        ValueError: if `task.task_type` is not a known enum value.
+        ValueError: if `task.task_type` is not a known enum value, or
+            `sub_tasks` schema invalid.
     """
     if not isinstance(task, dict):
         raise ValueError(f"task must be a dict, got {type(task).__name__}")
@@ -130,6 +251,7 @@ def choose_role(task: dict[str, Any], *, strict: bool = False) -> DelegationDeci
             warnings=[],
             delegation_id=None,
             task_type=task_type,
+            recommended_model_tier=None,
         )
         if strict:
             raise DelegationRejected(decision)
@@ -137,11 +259,14 @@ def choose_role(task: dict[str, Any], *, strict: bool = False) -> DelegationDeci
 
     role = TASK_TYPE_TO_ROLE[task_type]
     warnings: list[str] = []
-    # §3 model_tier hint (best-effort, not strict)
+    # §3 model_tier hint (best-effort, not strict) — v0.5.5
     if isinstance(task.get("constraints"), list):
         for c in task["constraints"]:
             if isinstance(c, str) and "main" in c.lower() and "model" in c.lower():
                 warnings.append("task mentions 'main model' — orchestrator may promote model_tier")
+
+    # v0.5.7: 자동 model_tier 결정
+    recommended_tier = recommend_model_tier(task)
 
     return DelegationDecision(
         role=role,
@@ -150,4 +275,77 @@ def choose_role(task: dict[str, Any], *, strict: bool = False) -> DelegationDeci
         warnings=warnings,
         delegation_id=_generate_delegation_id(),
         task_type=task_type,
+        recommended_model_tier=recommended_tier,
     )
+
+
+def choose_roles(
+    task: dict[str, Any],
+    *,
+    strict: bool = False,
+) -> list[DelegationDecision]:
+    """v0.5.7: 멀티 컴포넌트 fan-out 일괄 위임 결정.
+
+    - `task.sub_tasks` 가 비어있거나 없으면 단일 결과 (`[choose_role(task)]`)
+    - `task.sub_tasks` 가 있으면 각 sub-task 별로 `choose_role` 호출하되
+      `sub_id` 를 DelegationDecision 에 박고, delegation_id 는
+      `<parent>-<sub_id>` 형식으로 생성한다.
+    - 부모 task 자체는 별도 decision 으로 앞에 포함 (parent delegation_id).
+    - §6.3 매치 시 (부모 또는 sub) 즉시 `must_not_delegate=True` decision 반환
+      (전체 fan-out 거부, strict=True 면 raise).
+
+    Args:
+        task: A task dict matching contract v1 §4 + §4.2.
+        strict: 부모 또는 sub 가 §6.3 위반 시 raise DelegationRejected.
+
+    Returns:
+        list[DelegationDecision]. 첫 항목이 부모, 이후가 sub-task 순서.
+
+    Raises:
+        DelegationRejected, ValueError (sub-task schema invalid).
+    """
+    if not isinstance(task, dict):
+        raise ValueError(f"task must be a dict, got {type(task).__name__}")
+
+    sub_tasks = task.get("sub_tasks") or []
+    if not isinstance(sub_tasks, list):
+        raise ValueError(f"task.sub_tasks must be a list, got {type(sub_tasks).__name__}")
+
+    # 부모 task 에 대한 decision
+    parent_decision = choose_role(task, strict=False)
+    # strict=True 면 부모도 enforce
+    if parent_decision.must_not_delegate and strict:
+        raise DelegationRejected(parent_decision)
+
+    parent_delegation_id = parent_decision.delegation_id
+
+    if not sub_tasks:
+        # 단일 위임 모드 — fan-out 아님
+        return [parent_decision]
+
+    # fan-out: 각 sub-task 별 decision
+    decisions: list[DelegationDecision] = [parent_decision]
+    for sub in sub_tasks:
+        _validate_sub_task(sub, parent_delegation_id)
+        # sub-task 를 단일 task 로 위장해서 choose_role 호출
+        sub_as_task: dict[str, Any] = {
+            "task_type": sub["task_type"],
+            "brief": sub.get("brief", ""),
+            "expected_outputs": {
+                "primary_artifact": sub.get("primary_artifact", ""),
+                "artifact_kind": sub.get("artifact_kind", "other"),
+            },
+        }
+        sub_decision = choose_role(sub_as_task, strict=False)
+        sub_decision.sub_id = sub["sub_id"]
+        # delegation_id 를 sub_id suffix 형식으로 덮어쓰기 (parent prefix 안 씀 —
+        # parent delegation_id 가 바뀌어도 sub 가 추적 가능하도록, sub_id 만 suffix)
+        sub_decision.delegation_id = _generate_delegation_id_with_suffix(sub["sub_id"])
+        # sub 의 parent_delegation_id 자동 채움 (caller 가 미리 채웠다면 그대로 둠)
+        if sub.get("parent_delegation_id") is None:
+            sub["parent_delegation_id"] = parent_delegation_id
+        decisions.append(sub_decision)
+        if sub_decision.must_not_delegate and strict:
+            raise DelegationRejected(sub_decision)
+
+    return decisions

--- a/workflow-source/workflow_kit/contract_v1/output_validator.py
+++ b/workflow-source/workflow_kit/contract_v1/output_validator.py
@@ -23,6 +23,10 @@ ALLOWED_ARTIFACT_KINDS = ("markdown", "python", "json", "toml", "text", "code", 
 REQUIRED_TOP_FIELDS = ("contract_version", "delegation_id", "completed_at", "worker", "result")
 REQUIRED_WORKER_FIELDS = ("session_id", "role", "model_tier")
 REQUIRED_RESULT_FIELDS = ("status", "summary", "artifacts", "written_paths", "next_step")
+# v0.5.7: fan-in sub_result 최소 필드
+REQUIRED_SUB_RESULT_FIELDS = ("sub_id", "delegation_id", "status", "summary", "written_paths")
+# v0.5.7: artifacts action enum (created/modified/deleted)
+ALLOWED_ARTIFACT_ACTIONS = ("created", "modified", "deleted")
 
 
 @dataclass
@@ -150,6 +154,19 @@ def validate_output(
                     f"result.artifacts[{idx}].kind",
                     f"must be one of {ALLOWED_ARTIFACT_KINDS}, got {artifact['kind']!r}",
                 ))
+            # v0.5.7: action enum (optional, but validated if present)
+            if "action" in artifact and artifact["action"] not in ALLOWED_ARTIFACT_ACTIONS:
+                errors.append(OutputValidationError(
+                    f"result.artifacts[{idx}].action",
+                    f"must be one of {ALLOWED_ARTIFACT_ACTIONS}, got {artifact['action']!r}",
+                ))
+            # v0.5.7: action 통계 (added/removed/total) — optional, validated if present
+            for stat_field in ("added", "removed", "total"):
+                if stat_field in artifact and not isinstance(artifact[stat_field], int):
+                    errors.append(OutputValidationError(
+                        f"result.artifacts[{idx}].{stat_field}",
+                        "must be an int",
+                    ))
     if "written_paths" in result and not isinstance(result["written_paths"], list):
         errors.append(OutputValidationError("result.written_paths", "must be a list"))
     if "next_step" in result:
@@ -176,6 +193,175 @@ def validate_output(
                         "result.validation_result.status",
                         f"must be one of ('pass', 'fail', 'skipped'), got {vr['status']!r}",
                     ))
+
+    return OutputValidationResult(
+        is_valid=not errors,
+        errors=errors,
+        warnings=warnings,
+    )
+
+
+# v0.5.7: sub_result status → 부모 status 자동 계산
+SUB_RESULT_TO_PARENT_STATUS = {
+    # (any_failed, any_partial) → parent status
+    (False, False): "ok",
+    (False, True): "partial",
+    (True, False): "failed",
+    (True, True): "failed",
+}
+
+
+def _validate_sub_result_entry(
+    sub: Any,
+    idx: int,
+    expected_parent: str | None,
+) -> tuple[list[OutputValidationError], str | None]:
+    """Validate a single sub_result entry. Returns (errors, status)."""
+    errs: list[OutputValidationError] = []
+    if not isinstance(sub, dict):
+        errs.append(OutputValidationError(
+            f"result.sub_results[{idx}]",
+            f"must be a dict, got {type(sub).__name__}",
+        ))
+        return errs, None
+    for field_name in REQUIRED_SUB_RESULT_FIELDS:
+        if field_name not in sub:
+            errs.append(OutputValidationError(
+                f"result.sub_results[{idx}].{field_name}",
+                "missing required field",
+            ))
+    if "delegation_id" in sub and expected_parent is not None:
+        # sub_result delegation_id 가 parent delegation_id 로 시작하는지 (prefix check)
+        if not str(sub["delegation_id"]).startswith(expected_parent):
+            errs.append(OutputValidationError(
+                f"result.sub_results[{idx}].delegation_id",
+                f"must start with parent delegation_id {expected_parent!r}, "
+                f"got {sub['delegation_id']!r}",
+            ))
+    if "status" in sub and sub["status"] not in ALLOWED_STATUS:
+        errs.append(OutputValidationError(
+            f"result.sub_results[{idx}].status",
+            f"must be one of {ALLOWED_STATUS}, got {sub['status']!r}",
+        ))
+    if "written_paths" in sub and not isinstance(sub["written_paths"], list):
+        errs.append(OutputValidationError(
+            f"result.sub_results[{idx}].written_paths",
+            "must be a list",
+        ))
+    return errs, sub.get("status") if isinstance(sub, dict) else None
+
+
+def _compute_aggregated_status(sub_statuses: list[str]) -> str:
+    """Compute aggregated parent status from sub_result statuses (§5.2.1)."""
+    any_failed = any(s == "failed" for s in sub_statuses)
+    any_partial = any(s == "partial" for s in sub_statuses)
+    return SUB_RESULT_TO_PARENT_STATUS[(any_failed, any_partial)]
+
+
+def validate_fanin_output(
+    payload: Any,
+    expected_parent_delegation_id: str | None = None,
+) -> OutputValidationResult:
+    """v0.5.7: Validate a fan-in payload (§5.2).
+
+    Runs the standard §5 schema validation first, then enforces the
+    fan-in-specific rules:
+    1. `parent_delegation_id` matches expected (when provided)
+    2. `sub_results` is a list; each entry has the 5 required fields
+    3. Each sub_result.delegation_id starts with the parent delegation_id
+    4. `result.status` is consistent with sub_results aggregation
+       (when sub_results is present)
+
+    Args:
+        payload: A sub-agent fan-in report dict (§5.2).
+        expected_parent_delegation_id: If provided, asserts
+            `payload.parent_delegation_id` matches AND that all
+            `sub_results[].delegation_id` start with this value.
+
+    Returns:
+        OutputValidationResult. Aggregated status mismatch is reported
+        as an error (not warning) — it indicates a fan-in bug.
+    """
+    # First, run standard §5 validation
+    base = validate_output(payload, expected_delegation_id=None)
+    errors: list[OutputValidationError] = list(base.errors)
+    warnings: list[str] = list(base.warnings)
+
+    if not base.is_valid:
+        # base validate_output already reported; do not attempt fan-in logic
+        # on a malformed payload (it may not be a dict).
+        return OutputValidationResult(
+            is_valid=False, errors=errors, warnings=warnings,
+        )
+
+    # parent_delegation_id field
+    parent_id = payload.get("parent_delegation_id")
+    if expected_parent_delegation_id is not None:
+        if parent_id is None:
+            errors.append(OutputValidationError(
+                "parent_delegation_id",
+                f"required when sub_results present, expected "
+                f"{expected_parent_delegation_id!r}",
+            ))
+        elif parent_id != expected_parent_delegation_id:
+            errors.append(OutputValidationError(
+                "parent_delegation_id",
+                f"expected {expected_parent_delegation_id!r}, got {parent_id!r}",
+            ))
+
+    result = payload.get("result", {})
+    if not isinstance(result, dict):
+        return OutputValidationResult(
+            is_valid=not errors, errors=errors, warnings=warnings,
+        )
+
+    sub_results = result.get("sub_results")
+    if sub_results is None:
+        # Not a fan-in payload — base validation suffices
+        return OutputValidationResult(
+            is_valid=not errors, errors=errors, warnings=warnings,
+        )
+
+    # parent_delegation_id 가 있는데 sub_results 가 있으면 fan-in 모드
+    if parent_id is None:
+        errors.append(OutputValidationError(
+            "parent_delegation_id",
+            "required when result.sub_results is present",
+        ))
+
+    if not isinstance(sub_results, list):
+        errors.append(OutputValidationError(
+            "result.sub_results", "must be a list",
+        ))
+        return OutputValidationResult(
+            is_valid=not errors, errors=errors, warnings=warnings,
+        )
+
+    if len(sub_results) == 0:
+        errors.append(OutputValidationError(
+            "result.sub_results", "must contain at least 1 sub-result",
+        ))
+
+    sub_statuses: list[str] = []
+    for idx, sub in enumerate(sub_results):
+        sub_errs, sub_status = _validate_sub_result_entry(
+            sub, idx, expected_parent_delegation_id
+        )
+        errors.extend(sub_errs)
+        if sub_status in ALLOWED_STATUS:
+            sub_statuses.append(sub_status)
+
+    # Aggregated status consistency check
+    if sub_statuses and "status" in result:
+        computed = _compute_aggregated_status(sub_statuses)
+        declared = result["status"]
+        if computed != declared:
+            errors.append(OutputValidationError(
+                "result.status",
+                f"declared {declared!r} but sub_results aggregate to {computed!r} "
+                f"(any_failed={any(s=='failed' for s in sub_statuses)}, "
+                f"any_partial={any(s=='partial' for s in sub_statuses)})",
+            ))
 
     return OutputValidationResult(
         is_valid=not errors,


### PR DESCRIPTION
## 요약

v0.5.6 §5/§6 P0 enforcement 위에 v0.5.5 pilot P1/P2 priorities 묶어서 enforce. v0.5.7 의 핵심 가치는 **"multi-component sub-task 를 contract v1 spec + Python enforcement 둘 다로 박는다"**.

## TASK-V057-001 (4 sub-task)

### A. §4.2/§5.2 multi-component fan-out/in
- `delegator.choose_roles(task, strict=False) -> list[DelegationDecision]`
  - `task.sub_tasks` 가 있으면 fan-out (parent + N sub decisions)
  - sub_id + sub-prefix delegation_id, parent delegation_id auto-fill
  - §6.3 매치 (parent or sub) 시 전체 reject
- `output_validator.validate_fanin_output(payload, expected_parent_delegation_id=None)`
  - sub_results 5 required fields (sub_id, delegation_id, status, summary, written_paths)
  - sub_result.delegation_id 가 parent prefix 로 시작
  - aggregated status consistency (any failed→failed, any partial→partial, else ok)
- spec: §4.2 sub-task input + §5.2 sub_result fan-in output + §5.1 의 sub_results/parent_delegation_id 필드
- 회귀: `tests/check_contract_v1_multi_component.py` (17 check, **신규**)

### B. §6.3 cross-ref / fan-in 통합 row 추가
- `MUST_NOT_DELEGATE_MARKERS` 7→9: `handoff`, `backlog`, `state.json`, `ask_user`, `우선순위`, `통합/리뷰`, `PR 본문` + **`cross-ref`** + **`fan-in 통합`**
- 매치 검사: `sub_tasks[].brief` 까지 haystack 포함 (sub marker 도 parent reject — fan-out 정합성)
- 회귀: `tests/check_contract_v1_direct_only.py` 확장 (DIRECT_ONLY_ACTIONS 7→9)

### C. (P2) `required_model_tier` + `recommend_model_tier`
- main 후보 keyword 5개 (case-insensitive substring): `아키텍처`, `정책`, `5+ 파일`, `cross-cutting`, `5+ source`
- 명시 `task.required_model_tier` 있으면 override
- `choose_role` 결과의 `decision.recommended_model_tier` 에 자동 결정값 박힘
- spec: §4.1 input schema 에 `task.required_model_tier` 필드 추가
- 회귀: `tests/check_contract_v1_delegator.py` (4 model_tier check 추가)

### D. (P2) `artifacts` action + stats 분리
- `result.artifacts[i].action` (created/modified/deleted) enum 검증
- `result.artifacts[i].added/removed/total` (int) 검증
- 기존 `path`/`kind`/`lines` 그대로 (backward compatible)
- 회귀: `tests/check_contract_v1_output_validator.py` 의 action+stats 검증 케이스 (8 violation → 10 violation)

### 추가: Mavis 측 wire 가이드
- `workflow-source/core/orchestrator_contract_v1_wire_guide.md` (250 줄, **신규**)
- single-task / fan-out/in / model_tier 3 패턴 + Mavis 측 안티패턴 5종

## 회귀 종합

| 회귀 | 결과 |
| --- | --- |
| `check_bootstrap_mcp_roundtrip.py` | ✅ 5/5 |
| `check_docs.py` | ✅ **114** markdown PASS (3 신규) |
| `check_contract_v1_roundtrip.py` | ✅ |
| `check_contract_v1_role_mapping.py` | ✅ |
| `check_contract_v1_direct_only.py` | ✅ (**9 actions** [7 v0.5.6 + 2 v0.5.7]) |
| `check_contract_v1_output_validator.py` | ✅ (4 pilot + **10** violation + 4 pilot doc) |
| `check_contract_v1_delegator.py` | ✅ (4 mapping + **9** rejection + 4 model_tier) |
| **`check_contract_v1_multi_component.py`** (v0.5.7 신규) | ✅ (**17 check**) |
| `check_pilot_phase11_contract_v1.py` | ✅ |

## 변경 통계

- 9 files changed
- +1,532 / -23
- 신규 6 (multi_component 회귀 + wire 가이드 + Beta-v0.5.7 + 3 메모리)
- 확장 6 (spec/delegator/validator/init + 2 회귀)

## spec 갭 (v0.5.7)

1. `sub_result` status enum: spec §5.2 명시 — `ok` / `partial` / `failed` (parent 와 동일)
2. `parent_delegation_id` 위치: spec §5 output top-level (sub_results 있으면 필수)

## 다음 단계 (v0.5.8 후보)

- Mavis 측 `choose_role`/`choose_roles` 을 mavis-team engine hook 에 자동 wire
- PyPI 배포 (v0.5.2 부터 보류)
- fan-out/in pilot walkthrough (Devhub N+1 endpoint 4 동시 처리)
- contract v2 streaming/observability

## 메모리 layer

- `ai-workflow/memory/release/v0.5.7/PROJECT_PROFILE.md`
- `ai-workflow/memory/release/v0.5.7/session_handoff.md`
- `ai-workflow/memory/release/v0.5.7/state.json`
- `ai-workflow/memory/release/v0.5.7/backlog/2026-06-08.md`